### PR TITLE
docs: update README, CHANGELOG, and plugin.json for v7.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productionos",
-  "description": "Your AI engineering team — 64 agents, 21 commands, 15+ hooks, 6 CLI tools, self-eval, design auditing, UX analysis. Native embedding into Claude Code with default-on self-evaluation, interactive HTML mockups, user story generation, and cross-session instincts.",
+  "description": "Your AI engineering team — 65 agents, 35 commands, 15+ hooks, 6 CLI tools, self-eval, design auditing, UX analysis. Native embedding into Claude Code with default-on self-evaluation, interactive HTML mockups, user story generation, and cross-session instincts. Zero external dependencies.",
   "version": "7.0.0",
   "author": {
     "name": "Shaheer Khawaja",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [7.0.0] - 2026-03-21
+
+### Added — The Design Conscience
+- **Self-Evaluation Protocol (default-on)** — 7-question self-eval after every agent action: quality, necessity, correctness, dependencies, completeness, learning, honesty
+- **Quality Loop Controller** — Self-check → Self-eval → Self-heal → Learn cycle with score gating (>= 8.0 pass, 6.0-7.9 self-heal, < 6.0 block)
+- **`/self-eval` command** — Standalone evaluation of last output, session, or git diff
+- **`/designer-upgrade` command** — Full UI/UX redesign pipeline: audit → design system → interactive HTML mockups → browser annotation → implementation plan
+- **`/ux-genie` command** — User stories from UI guidelines, journey mapping, friction analysis, agent dispatch
+- **`/build-productionos` command** — Smart router that routes any intent to the right pipeline
+- **8 new agents** — self-evaluator, designer-upgrade, mockup-generator, design-system-architect, ux-genie, user-story-mapper, quality-loop-controller, session-context-manager
+- **14 absorbed commands** — brainstorming, writing-plans, tdd, debug, plan-ceo-review, plan-eng-review, review, ship, qa, qa-only, browse, retro, document-release (from gstack, superpowers, ECC)
+- **Session context management** — L0/L1/L2 progressive loading, context rot detection, cross-session instinct transfer
+- **SELF-EVAL-PROTOCOL.md template** — Embedded in PREAMBLE postamble for all flows
+
+### Changed
+- Agent count: 56 → 65
+- Command count: 21 → 35
+- Zero external dependencies — all core workflows absorbed natively
+- CLAUDE.md, ARCHITECTURE.md, PREAMBLE.md, INVOCATION-PROTOCOL.md rewritten for v7
+- VERSION: 6.3.0 → 7.0.0
+
 ## [6.0.0] - 2026-03-20
 
 ### Added — Native Embedding Architecture

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **The problem:** You're building a production SaaS -- complex backend, frontend, infrastructure, security, billing -- and you need the output of a 10-person engineering team. You have one person.
 
-**The solution:** ProductionOS turns Claude Code into a full engineering department. 65 agents fill the roles you can't hire fast enough: code reviewer, QA engineer, security auditor, solutions architect, CTO-level strategic reviewer, and release manager. One command audits your entire codebase. Another deploys 500 agents to research any topic exhaustively. Another runs recursive improvement loops until every quality dimension hits 10/10.
+**The solution:** ProductionOS turns Claude Code into a full engineering department. 65 agents across 35 commands fill the roles you can't hire fast enough: code reviewer, QA engineer, security auditor, solutions architect, CTO-level strategic reviewer, designer, and release manager. One command audits your entire codebase. Another deploys 500 agents to research any topic exhaustively. Another runs recursive improvement loops until every quality dimension hits 10/10. A default-on self-evaluation protocol questions every action before it ships.
 
 Built by a solo founder who needed to ship production-grade code at hackathon pace -- and couldn't afford to ship garbage.
 
@@ -23,9 +23,6 @@ Total time: 10-30 minutes. Total cost: ~$1-5.
 ## Installation
 
 ```bash
-# One command (coming soon)
-npx productionos@latest
-
 # Via Claude Code plugin marketplace
 claude plugin install productupgrade
 
@@ -33,63 +30,116 @@ claude plugin install productupgrade
 git clone https://github.com/ShaheerKhawaja/ProductionOS.git ~/.claude/plugins/marketplaces/productupgrade
 ```
 
-## Commands
+## Commands (35)
 
 ### Start Here
 ```
+/build-productionos          Smart router — routes any intent to the right pipeline
 /production-upgrade          Audit + fix any codebase (the entry point)
 /productionos-help           Usage guide and recommended workflows
 ```
 
-### When You Need More
+### Orchestrative (recursive, nth-iteration)
+```
+/omni-plan-nth               Recursive until 10/10 across ALL dimensions
+/auto-swarm-nth "task"       Recursive swarm until 100% coverage + 10/10 quality
+```
+
+### Pipeline (structured, single-pass with convergence)
 ```
 /omni-plan                   Full 13-step pipeline with tri-tiered judging
 /auto-swarm "task"           Throw 7-77 parallel agents at any task
-/deep-research [topic]       8-phase research with citation verification
-/security-audit              7-domain OWASP/MITRE/NIST security sweep
+/frontend-upgrade            CEO vision + parallel swarm frontend transformation
+/designer-upgrade            Full UI/UX redesign — audit → design system → HTML mockups
+/ux-genie                    User stories + journey maps + friction analysis + agent dispatch
 ```
 
-### When You Need Everything
+### Quality & Self-Evaluation (v7.0)
 ```
-/omni-plan-nth               Recursive until 10/10 across ALL dimensions
-/auto-swarm-nth "task"       Recursive swarm until 100% coverage
+/self-eval                   Self-evaluate recent work (default-on in all flows)
+```
+
+### Nuclear Scale
+```
 /max-research [topic]        500-1000 agents in ONE wave (nuclear option)
 ```
 
-### Frontend (v6.0)
+### Specialized
 ```
-/frontend-upgrade            CEO vision + parallel swarm frontend transformation
-```
-
-### Specialized Tools
-```
+/deep-research [topic]       8-phase research with citation verification
+/security-audit              7-domain OWASP/MITRE/NIST security sweep
 /agentic-eval                CLEAR v2.0 quality framework evaluation
 /context-engineer            Token-optimized context packaging
 /logic-mode [idea]           Business idea → production-ready validation
 /learn-mode [topic]          Interactive code tutor (explain any codebase)
+/auto-mode [idea]            Idea-to-running-code pipeline (10-phase, 5 gates)
+```
+
+### Absorbed Skills (v7.0 -- zero external deps)
+```
+/brainstorming               Idea exploration before building
+/writing-plans               Step-by-step implementation plans
+/tdd                         Test-driven development workflow
+/debug                       Systematic debugging with hypothesis tracking
+/plan-ceo-review             CEO/founder-mode strategic review
+/plan-eng-review             Engineering architecture review
+/review                      Pre-landing code review
+/ship                        Merge, test, version, push, create PR
+/qa                          Systematic QA testing with health scoring
+/qa-only                     Report-only QA (no fixes applied)
+/browse                      Headless browser for QA and site inspection
+/retro                       Engineering retrospective with trend tracking
+/document-release            Post-ship documentation update
+```
+
+### Lifecycle
+```
+/productionos-pause          Save pipeline state for later resumption
+/productionos-resume         Resume paused pipeline from checkpoint
 /productionos-update         Self-update from GitHub
 ```
 
-### CLI Tools (v6.0)
+### CLI Tools
 ```
 pos-init                     Initialize ~/.productionos/ state directory
 pos-config list|get|set      Manage ProductionOS settings
 pos-analytics                Usage dashboard (events, top skills, sessions)
 pos-update-check             Version check with snooze
+pos-review-log               Append review results to log
+pos-telemetry                Log skill usage events
 ```
 
-## What's New in v6.0 — The Nervous System
+## What's New in v7.0 -- The Design Conscience
 
-ProductionOS v6.0 transforms from a command you invoke to an always-present AI engineering team:
+### Self-Evaluation (default-on)
+- **Self-Eval Protocol** -- 7 questions after every agent action: quality, necessity, correctness, dependencies, completeness, learning, honesty
+- **Quality Loop Controller** -- Self-check → Self-eval → Self-heal → Learn cycle on all outputs
+- **Score Gating** -- >= 8.0 passes, 6.0-7.9 triggers self-heal loop, < 6.0 blocks and escalates
+- **`/self-eval` command** -- Standalone evaluation of last output, session, or git diff
 
-- **9 lifecycle hooks** — SessionStart banner, PreToolUse security scan on auth/payment files, PostToolUse telemetry + review hints after 10+ edits, Stop session handoff + instinct extraction
-- **6 CLI tools** — `pos-init`, `pos-config`, `pos-analytics`, `pos-update-check`, `pos-review-log`, `pos-telemetry`
-- **4 auto-activating skills** — Security-scan (auth/payment patterns), frontend-audit (tsx/vue/css), continuous-learning (instinct extraction), productionos (package.json/CLAUDE.md)
-- **HumanLayer stakes classification** — Every agent tagged LOW/MEDIUM/HIGH with approval gates for destructive operations
-- **79-command skill registry** — Invokes skills from superpowers, gstack, and GSD when relevant
-- **Persistent state** — `~/.productionos/` with config, analytics, sessions, instincts
+### Design & UX (3 new commands, 5 new agents)
+- **`/designer-upgrade`** -- Full UI/UX redesign: audit → design system → interactive HTML mockups → browser annotation → implementation plan
+- **`/ux-genie`** -- User stories from UI guidelines, journey mapping, friction analysis, agent dispatch
+- **Mockup Generator** -- Self-contained HTML mockups with annotation overlay, dark mode, responsive preview
+- **Design System Architect** -- Token system creation from codebase analysis
 
-## 56 Agents
+### Skill Absorption (zero external deps)
+- **14 commands absorbed** from gstack, superpowers, and ECC -- `/brainstorming`, `/writing-plans`, `/tdd`, `/debug`, `/plan-ceo-review`, `/plan-eng-review`, `/review`, `/ship`, `/qa`, `/qa-only`, `/browse`, `/retro`, `/document-release`, `/build-productionos`
+- **Smart router** -- `/build-productionos` routes any intent to the right pipeline automatically
+- ProductionOS is now **fully self-contained** -- no external plugin dependencies for core functionality
+
+### Session Context Management
+- **Progressive context loading** -- L0 (always) / L1 (on demand) / L2 (when referenced)
+- **Context rot detection** -- Monitors for repeated work, contradictions, quality drift
+- **Cross-session instinct transfer** -- Patterns with confidence > 0.8 persist globally
+
+### v6.0 Foundation (retained)
+- **9 lifecycle hooks** -- SessionStart, PreToolUse security, PostToolUse telemetry/review, Stop handoff
+- **4 auto-activating skills** -- Security-scan, frontend-audit, continuous-learning, productionos
+- **HumanLayer stakes classification** -- Every agent tagged LOW/MEDIUM/HIGH
+- **Persistent state** -- `~/.productionos/` with config, analytics, sessions, instincts
+
+## 65 Agents
 
 These aren't chat personas -- they're specialized workflows with defined inputs, outputs, tool restrictions, and quality criteria. All agents have YAML frontmatter with `model`, `tools`, `subagent_type`, `stakes`, and behavioral `Red Flags`. Read-only agents (judges, auditors) cannot modify code. Execution agents (fixers, healers) cannot evaluate their own work.
 
@@ -102,15 +152,17 @@ These aren't chat personas -- they're specialized workflows with defined inputs,
 | V5.2 | 5 | debate-tribunal, ecosystem-scanner, gap-analyzer, recursive-orchestrator, verification-gate |
 | V5.3 | 9 | discuss-phase, stub-detector, plan-checker, architecture-designer, intake-interviewer, nyquist-filler, prd-generator, requirements-tracer, scaffold-generator |
 | V5.3+ | 6 | version-control, e2e-architect, rag-expert, db-creator, aiml-engineer, infra-setup |
-| V6.0 | 1 | approval-gate (HumanLayer-inspired stakes-based approval) |
+| V6.0 | 2 | approval-gate, browser-controller |
+| V7.0 | 8 | self-evaluator, designer-upgrade, mockup-generator, design-system-architect, ux-genie, user-story-mapper, quality-loop-controller, session-context-manager |
 
 ## Estimated Costs
 
 | Command | Agents | Estimated Cost |
 |---------|--------|---------------|
-| /production-upgrade | 7-49 | $1-5 per run |
+| /production-upgrade | 7-55 | $1-5 per run |
 | /omni-plan | 14-147 | $3-15 per run |
 | /auto-swarm | 7-77 | $1-8 per run |
+| /designer-upgrade | 5-20 | $2-8 per run |
 | /max-research | 500-1000 | $15-75 per run |
 | /deep-research | 3-10 | $0.50-2 per run |
 
@@ -120,11 +172,15 @@ Costs depend on codebase size, depth setting, and model. Use `--profile budget` 
 
 **Recursive convergence.** Other tools do one review pass. ProductionOS loops: review → plan → fix → validate → re-score. If quality drops, it rolls back. If progress stalls, it pivots strategy. It doesn't stop until the target is hit or it proves the target is unreachable.
 
+**Self-evaluation by default.** Every action is questioned: Was this necessary? Is this correct? Did I miss dependencies? Am I being honest about quality? Scores below 8.0 trigger automatic self-heal loops. This catches the "looks good but isn't" problem.
+
 **Evaluators can't grade their own work.** The agents that fix code are different from the agents that judge it. The judge is read-only -- it cannot modify code, only score it. This prevents the self-grading inflation problem that plagues single-pass AI code review.
 
 **Tri-tiered tribunal.** Three independent judges with different perspectives (correctness, practicality, adversarial) must reach consensus. If they disagree, they debate. This catches issues that any single reviewer would miss.
 
 **Observable execution.** Cost estimation before every expensive run. Convergence dashboard showing real-time grade progression. Run history tracking across sessions. You see the machine working, not a black box.
+
+**Zero external dependencies.** All 35 commands work out of the box -- no need to install gstack, superpowers, or ECC separately. Core workflows (brainstorming, TDD, debugging, code review, shipping) are absorbed natively.
 
 ## Built For
 
@@ -137,19 +193,20 @@ Costs depend on codebase size, depth setting, and model. Use `--profile budget` 
 
 ```bash
 bun run skill:check        # Plugin health score (10/10)
-bun run validate           # Agent validation (56/56)
-bun test                   # Full test suite (183+ tests)
+bun run validate           # Agent validation (65/65)
+bun test                   # Full test suite (196+ tests)
 ```
 
 ## Tech
 
-- 56 agent definitions with YAML frontmatter (model routing, tool constraints, stakes classification)
+- 65 agent definitions with YAML frontmatter (model routing, tool constraints, stakes classification)
+- 35 commands (14 absorbed from gstack/superpowers/ECC)
 - 10-layer prompt architecture (Emotion → Meta → Scratchpad → Context → CoT → ToT → GoT → CoD → Generated Knowledge → Distractor-Augmented)
+- Default-on self-evaluation protocol (7-question quality gate on all outputs)
 - 9 lifecycle hooks (SessionStart, PreToolUse security, PostToolUse telemetry/review, Stop handoff)
 - 6 CLI tools for config, analytics, telemetry, version management
 - 4 auto-activating skills with file pattern matching
 - Executable convergence engine (TypeScript, Algorithm 1 + Algorithm 6)
-- 79-command skill registry (superpowers + gstack + GSD integration)
 - Persistent state at ~/.productionos/ (config, analytics, instincts, sessions)
 - HumanLayer-inspired approval gate for HIGH-stakes operations
 - CI/CD pipeline (GitHub Actions: validate + lint + convergence check)
@@ -157,16 +214,16 @@ bun test                   # Full test suite (183+ tests)
 
 ## Architecture Influences
 
-- [gstack](https://github.com/garry-tan/gstack) — hooks, CLI tools, preamble pattern, micro-state files
-- [superpowers](https://github.com/anthropics/claude-code) — behavioral gates, red flags, evidence-first
-- [everything-claude-code](https://github.com/shobrook/everything-claude-code) — continuous learning, instinct system
-- [12-factor-agents](https://github.com/humanlayer/12-factor-agents) — small focused agents, unified state
-- [HumanLayer](https://github.com/humanlayer/humanlayer) — stakes classification, approval as tool call
-- [get-shit-done](https://github.com/gsd-framework) — wave-based execution, project management
+- [gstack](https://github.com/garry-tan/gstack) -- hooks, CLI tools, preamble pattern, micro-state files
+- [superpowers](https://github.com/anthropics/claude-code) -- behavioral gates, red flags, evidence-first
+- [everything-claude-code](https://github.com/shobrook/everything-claude-code) -- continuous learning, instinct system
+- [12-factor-agents](https://github.com/humanlayer/12-factor-agents) -- small focused agents, unified state
+- [HumanLayer](https://github.com/humanlayer/humanlayer) -- stakes classification, approval as tool call
+- [get-shit-done](https://github.com/gsd-framework) -- wave-based execution, project management
 
 ## Version
 
-6.2.0
+7.0.0
 
 ## Author
 


### PR DESCRIPTION
## Summary
- Update README to document all v7.0 features (self-eval, designer-upgrade, ux-genie, skill absorption)
- Fix stale references (was showing v6.0 as latest, 56 agents, 21 commands)
- Add v7.0.0 entry to CHANGELOG with all new agents, commands, and changes
- Fix plugin.json agent count (64 → 65) and command count (21 → 35)

## What Changed
- **README.md**: Complete rewrite of commands section (35 commands), What's New section (v7.0), agent table (65 agents), tech summary, validation counts
- **CHANGELOG.md**: Added [7.0.0] entry documenting 8 new agents, 14 absorbed commands, self-eval protocol, design features
- **plugin.json**: Fixed description to show accurate counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)