### PR TITLE
feat: enrich designer-upgrade  skills

### DIFF
--- a/agents/designer-upgrade.md
+++ b/agents/designer-upgrade.md
@@ -135,10 +135,102 @@ Produce `.productionos/designer-upgrade/DESIGN-SYSTEM.md`:
 - Border widths: 0/1/2/4
 - Shadows: sm/md/lg/xl (with values)
 
-### Motion
-- Duration: fast/normal/slow (100ms/200ms/400ms)
-- Easing: ease-in/ease-out/ease-in-out/spring
-- Usage rules: when to animate, when not to
+### Motion (powered by userinterface-wiki + interface-craft)
+**MANDATORY:** Load `userinterface-wiki` (152 rules) + `interface-craft` (storyboard + dialkit + critique) before ANY motion/animation work.
+
+**Duration Scale (userinterface-wiki calibrated):**
+- Micro: 80-120ms (hover, active states)
+- Fast: 120-180ms (press, toggle, tab switch)
+- Normal: 180-260ms (small state changes, dropdown)
+- Slow: 260-300ms (page transitions, modal enter)
+- NEVER exceed 300ms for user-initiated actions
+
+**Easing Decisions:**
+- Entrance → ease-out (decelerate in)
+- Exit → ease-in (accelerate out)
+- View transition → ease-in-out
+- Gesture/drag → spring (preserves velocity)
+- Progress/loading → linear (ONLY valid linear use)
+- Context menu → NO entrance, exit only
+
+**Spring Parameters:**
+- UI entrance: stiffness 250-350, damping 20-30
+- Snappy pop-in: stiffness 400-600, damping 20-30
+- Gesture follow: stiffness 150-250, damping 15-25
+- Stagger: under 50ms per item
+
+**Storyboard Animation Pattern (interface-craft):**
+Every multi-step animation uses:
+1. ASCII storyboard comment (shot list, top-to-bottom)
+2. TIMING object (single source for all delays)
+3. Element config objects (scale, position, spring per element)
+4. Stage integer pattern (`stage >= N` in animate props)
+
+```tsx
+/* ────────────────────────────────────────
+ * ANIMATION STORYBOARD
+ *   0ms    idle
+ * 300ms    card fades in, scale 0.85 → 1.0
+ * 900ms    heading highlights
+ * 1500ms   rows slide up (staggered 50ms)
+ * ──────────────────────────────────────── */
+const TIMING = { cardAppear: 300, heading: 900, rows: 1500 };
+const CARD = { initialScale: 0.85, finalScale: 1.0, spring: { type: "spring", stiffness: 300, damping: 25 } };
+```
+
+**DialKit Live Tuning (interface-craft):**
+During development, expose key values with `useDialKit`:
+```tsx
+const values = useDialKit("Card", {
+  blur: [4, 0, 20], scale: [0.95, 0.5, 1.5],
+  spring: { type: "spring", visualDuration: 0.4, bounce: 0.2 },
+  replay: () => replayAnimation(),
+});
+```
+Install: `npm install dialkit motion` + add `<DialRoot />` to layout.
+
+### Visual Design Rules (userinterface-wiki)
+- `visual-concentric-radius` — Inner radius = outer - padding
+- `visual-layered-shadows` — Layer 2-3 shadows for depth
+- `visual-no-pure-black-shadow` — Neutral oklch, never pure black
+- `visual-shadow-direction` — Single light source
+- `visual-border-alpha-colors` — Semi-transparent borders
+- `visual-button-shadow-anatomy` — 6-layer shadow for polished buttons
+
+### Typography Rules (userinterface-wiki)
+- `type-tabular-nums-for-data` — tabular-nums for dashboards/pricing
+- `type-text-wrap-balance-headings` — text-wrap: balance on headings
+- `type-text-wrap-pretty` — text-wrap: pretty on body text
+- `type-antialiased-on-retina` — -webkit-font-smoothing: antialiased
+- `type-font-display-swap` — font-display: swap
+- `type-variable-weight-continuous` — Use weight 100-900 with variable fonts
+
+### UX Laws (userinterface-wiki)
+- `ux-fitts-target-size` — Min 32px (48px mobile)
+- `ux-doherty-under-400ms` — Respond within 400ms
+- `ux-jakobs-familiar-patterns` — Use patterns users know
+- `ux-progressive-disclosure` — Show what matters, reveal later
+- `ux-peak-end-finish-strong` — End with clear success states
+
+### Design Critique Methodology (interface-craft)
+When reviewing/refining interfaces, apply the 4-lens critique:
+1. **Visual Design** — color, type, spacing, shadows, hierarchy
+2. **Interface Design** — layout, focus mechanism, information density
+3. **Interaction Consistency** — icon styles, dividers, borders, states
+4. **User Context** — cognitive load, Fitts's law, accessibility
+
+Micro-refinement patterns (from Raphael Salaja's "Refining Today"):
+- Reduce vertical rules to 2-3
+- Standardize divider treatment (all or none)
+- Tokenize category labels
+- Align stroke widths + colors
+- Tighten optical padding
+- Each refinement REDUCES visual weight
+
+### Reference Design Sites
+- **interfacecraft.dev** — "Reduce until clear, refine until right"
+- **userinterface.wiki** — 152 codified UI rules across 12 categories
+- **calligraph** — Character-level text animation with Motion
 
 ## Components
 {list of every UI component with variants, states, and tokens used}
@@ -146,6 +238,15 @@ Produce `.productionos/designer-upgrade/DESIGN-SYSTEM.md`:
 ## Patterns
 {layout patterns, form patterns, navigation patterns, data display patterns}
 ```
+
+## Phase 2.5: Animation Architecture (NEW — powered by interface-craft)
+
+For any component with animations, apply the **Storyboard Animation Pattern** before mockup generation:
+
+1. Write ASCII storyboard for each animated view
+2. Extract TIMING + element config objects
+3. Implement stage-driven animation with springs
+4. Add DialKit controls for live tuning during development
 
 ## Phase 3: HTML Mockup Generation
 

--- a/skills/design-critique.md
+++ b/skills/design-critique.md
@@ -1,0 +1,115 @@
+---
+name: design-critique
+description: "Structured interface review methodology. 4 lenses: visual design, interface design, interaction consistency, user context. Works with screenshots, component files, or URLs. Produces specific observations with impact and alternative."
+metadata:
+  author: raphael-salaja (forked + refactored for ProductionOS)
+  version: "1.0.0"
+  filePattern: "**/*.tsx,**/*.vue,**/*.jsx,**/*.svelte,**/*.css,**/components/**"
+  priority: 85
+---
+
+# Design Critique Skill
+
+Structured methodology for reviewing interfaces. Instead of vague feedback, produce specific, tangible observations organized into 4 lenses.
+
+## When to Use
+
+- Reviewing any UI component, page, or screen
+- After generating mockups in /designer-upgrade
+- Before shipping frontend changes
+- When user says "review", "critique", "check design", "what would you improve"
+
+## Input Formats
+
+Works with (in order of preference):
+1. **Screenshots** (best) — paste or provide path
+2. **Component files** — .tsx, .vue, .jsx, .svelte
+3. **Live URLs** — fetch and analyze
+
+## Critique Structure
+
+Always follow this sequence:
+
+### 1. Context
+What is this? What problem does it solve? Who uses it?
+
+### 2. First Impressions
+What do you notice in the first 3 seconds? What draws your eye? What feels off?
+
+### 3. Visual Design Lens
+Evaluate: color, typography, spacing, shadows, borders, visual weight, hierarchy.
+
+Format each finding as:
+```
+**{Issue name}** — {Specific observation about what's wrong}.
+{Impact on the user or aesthetic}. {What it could be instead}.
+```
+
+Example:
+```
+**Muddy shadows** — The card shadows use a large blur radius with low
+opacity, creating a hazy look rather than crisp depth. Tighter, more
+directional shadows would give the layout a cleaner sense of elevation.
+```
+
+Key checks (from userinterface-wiki):
+- `visual-concentric-radius` — Inner radius = outer - padding for nested elements
+- `visual-layered-shadows` — Layer 2-3 shadows for realistic depth
+- `visual-no-pure-black-shadow` — Use neutral colors, never pure black
+- `visual-shadow-direction` — All shadows share same offset direction
+- `visual-border-alpha-colors` — Semi-transparent borders adapt to any bg
+- `visual-consistent-spacing-scale` — No arbitrary spacing values
+
+### 4. Interface Design Lens
+Evaluate: layout, component composition, information density, focus mechanism, data hierarchy.
+
+Key checks:
+- **Focusing mechanism** — Does one element clearly lead? Or do all compete equally?
+- **Vertical rule count** — How many implicit alignment lines? Reduce to 2-3 max.
+- **Toolbar complexity** — Is the toolbar adding weight without functional gain?
+- **Primary action placement** — Right side, emphasized (iOS pattern)
+- **Progressive disclosure** — Show what matters now, reveal complexity later
+
+### 5. Interaction Consistency Lens
+Evaluate: hover states, active states, transitions, animation timing, icon consistency.
+
+Key checks:
+- **Icon style consistency** — All outline OR all filled, never mixed
+- **Divider consistency** — If one list has dividers, all similar lists should
+- **Border treatment consistency** — One visual language for containers
+- **Active state presence** — All interactive elements need :active scale (0.95-1.05)
+- **Timing consistency** — Similar animations use identical timing
+
+### 6. User Context Lens
+Evaluate: cognitive load, Fitts's law compliance, Hick's law compliance, accessibility.
+
+Key checks:
+- `ux-fitts-target-size` — Min 32px targets (48px mobile)
+- `ux-hicks-minimize-choices` — Fewer options = faster decisions
+- `ux-millers-chunking` — Groups of 5-9
+- `ux-doherty-under-400ms` — Respond within 400ms
+- `ux-jakobs-familiar-patterns` — Use patterns users know
+
+### 7. Top Opportunities
+End with 3-5 prioritized improvements. Each must be:
+- Specific (not "improve spacing" but "reduce card padding from 24px to 16px")
+- Impactful (addresses the #1 user friction)
+- Achievable (not a full redesign, but a targeted fix)
+
+## Refinement Methodology (from Raphael Salaja's "Refining Today")
+
+When refining an interface that's already good (7/10+), apply these micro-refinement patterns:
+
+1. **Icon style alignment** — Audit all icons, pick ONE style (outline or filled), apply everywhere
+2. **Vertical rule reduction** — Count implicit alignment lines, reduce to 2-3
+3. **Toolbar simplification** — Remove visual containers on toolbars, use floating buttons
+4. **Primary action emphasis** — Move to right side, add visual weight
+5. **Divider standardization** — Pick one treatment (dividers or no dividers), apply everywhere
+6. **Category tokenization** — Style category/tag labels as tokens to differentiate from user text
+7. **Stroke width alignment** — All icon/line strokes at same width
+8. **Color variance reduction** — Reduce to 2-3 semantic colors, eliminate one-off colors
+9. **Optical padding balance** — Tighten padding so content feels balanced, not just mathematically centered
+10. **Weight reduction** — Each refinement should REDUCE visual weight of the interface
+
+## Output Location
+Write critique to: `.productionos/designer-upgrade/audit/design-critique.md`

--- a/skills/dialkit-live-tuning.md
+++ b/skills/dialkit-live-tuning.md
@@ -1,0 +1,160 @@
+---
+name: dialkit-live-tuning
+description: "Live parameter tuning for UI development. DialKit provides floating control panel with sliders, toggles, spring configs, and action buttons wired to component values. Parametric visualization philosophy."
+metadata:
+  author: raphael-salaja (forked + refactored for ProductionOS)
+  version: "1.0.0"
+  filePattern: "**/*.tsx,**/*.jsx,**/components/**"
+  bashPattern: "dialkit|useDialKit"
+  priority: 75
+---
+
+# DialKit Live Tuning Skill
+
+Expose key parameters so you can adjust them in real time and feel the difference instantly. DialKit gives you a floating control panel wired directly to the values driving your UI.
+
+## Core Philosophy: Live Tuning (Parametric Visualization)
+
+> "Duration, easing, spacing, shadows, blurs, position, scale — whatever you're trying to dial in, make it adjustable on the fly."
+
+Traditional workflow: change value → save → look → change again → save → refresh.
+Live tuning: drag slider → see result INSTANTLY. Feel the difference. Build intuition.
+
+**This changes everything.** You find combinations you never would have landed on by guessing.
+
+## When to Use
+
+- Tuning animation springs (visualDuration + bounce)
+- Finding the right spacing/padding/gap values
+- Dialing in shadow blur, opacity, border radius
+- Exploring color variations
+- Any time you'd normally hard-code a number and iterate
+
+## Installation
+
+```bash
+npm install dialkit motion
+```
+
+Layout setup (add as SIBLING, not wrapper):
+```tsx
+import { DialRoot } from "dialkit";
+import "dialkit/styles.css";
+
+export default function Layout({ children }) {
+  return (
+    <>
+      {children}
+      <DialRoot />
+    </>
+  );
+}
+```
+
+## The useDialKit Hook
+
+```tsx
+const values = useDialKit("Component Name", {
+  // Sliders: [default, min, max]
+  blur: [4, 0, 20],
+  scale: [0.95, 0.5, 1.5],
+  opacity: [0.8, 0, 1],
+  padding: [16, 4, 48],
+  borderRadius: [8, 0, 32],
+  gap: [12, 0, 32],
+
+  // Toggles (boolean)
+  showShadow: true,
+  darkMode: false,
+
+  // Spring configs (auto-generates visualDuration + bounce sliders)
+  spring: {
+    type: "spring",
+    visualDuration: 0.4,
+    bounce: 0.2,
+  },
+
+  // Actions (trigger buttons)
+  reset: () => handleReset(),
+  replay: () => replayAnimation(),
+
+  // Folders (organize related controls)
+  card: {
+    elevation: [2, 0, 5],
+    hoverScale: [1.02, 1.0, 1.1],
+  },
+});
+```
+
+### Parameter Types
+
+| Type | Syntax | Control |
+|------|--------|---------|
+| **Slider** | `[default, min, max]` | Draggable number |
+| **Toggle** | `true` / `false` | Boolean switch |
+| **Spring** | `{ type: "spring", visualDuration, bounce }` | Auto dual-slider |
+| **Action** | `() => fn()` | Click button |
+| **Folder** | `{ nested: ... }` | Collapsible group |
+
+### Spring Config Detail
+
+The spring type is the most powerful. Pass `visualDuration` (how long the spring feels) and `bounce` (overshoot amount). DialKit auto-generates sliders for both. The returned value is a full transition object — pass directly to Motion's `transition` prop.
+
+```tsx
+const values = useDialKit("Modal", {
+  entrance: {
+    type: "spring",
+    visualDuration: 0.35,
+    bounce: 0.15,
+  },
+});
+
+<motion.div transition={values.entrance} />
+```
+
+## Practical Prompts
+
+### Add to existing animation:
+```
+I have a card component with a hover animation. Add DialKit controls
+so I can tune the spring physics (visualDuration and bounce), scale
+on hover, and shadow blur in real time.
+```
+
+### Build with DialKit from scratch:
+```
+Create a spring-animated modal using Motion. Add DialKit controls for:
+entrance spring, overlay opacity, border radius, and a "replay" button.
+```
+
+### Explore visual variations:
+```
+Give me a toggle for iterations of the current graphic. Let me slide
+how many I want and how many columns they are displayed in. For every
+iteration, use a random set of parameters so I can see possibilities.
+```
+
+### Tune layout:
+```
+Add DialKit to this grid layout. Sliders for gap, padding, column
+count (1-6), and card border radius. Group card controls in a folder.
+```
+
+## Integration with Storyboard Animation
+
+Combine both patterns for maximum design velocity:
+```
+Build a notification toast that slides in from the top-right, holds
+for 3 seconds, then slides out. Use the storyboard animation pattern
+and add DialKit controls for the spring, hold duration, and vertical offset.
+```
+
+This gives you:
+1. Readable storyboard comment
+2. TIMING/config constants at the top
+3. Stage-driven animation
+4. Live sliders to tune every value in real time
+
+## Output
+DialKit setup goes in the component file. `<DialRoot />` in the layout.
+Remove DialKit before production deployment (dev-only tool).

--- a/skills/interface-craft/SKILL.md
+++ b/skills/interface-craft/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: interface-craft
+description: "Interface Craft by Josh Puckett — a toolkit for building polished, animated interfaces in React. Includes Storyboard Animation (human-readable animation DSL with stage-driven sequencing), DialKit (live control panels for tuning animation values), and Design Critique (systematic UI review based on Josh Puckett's methodology). Triggers on: animate, animation, transition, storyboard, entrance, motion, spring, easing, timing, dialkit, sliders, controls, tune, tweak, critique, review, feedback, audit, improve, polish, refine, redesign."
+argument-hint: "[description, file path, or sub-skill name]"
+---
+
+# Interface Craft
+
+**By Josh Puckett**
+
+A toolkit for building polished, animated interfaces. Write animations you can read like a script, then tune them with live controls.
+
+---
+
+## Skills
+
+| Skill | When to Use | Invoke |
+| --- | --- | --- |
+| [Storyboard Animation](storyboard-animation.md) | Writing or refactoring multi-stage animations into a human-readable DSL | `/interface-craft storyboard` or describe an animation |
+| [DialKit](dialkit.md) | Adding live control panels to tune animation/style values | `/interface-craft dialkit` or mention dials/sliders/controls |
+| [Design Critique](design-critique.md) | Systematic UI critique of a screenshot, component, or page | `/interface-craft critique` or paste a screenshot for review |
+
+## Quick Start
+
+### Storyboard Animation
+
+Turn any animation into a readable storyboard with named timing, config objects, and stage-driven sequencing:
+
+```tsx
+/* ─────────────────────────────────────────────────────────
+ * ANIMATION STORYBOARD
+ *
+ *    0ms   waiting for scroll into view
+ *  300ms   card fades in, scale 0.85 → 1.0
+ *  900ms   heading highlights
+ * 1500ms   rows slide up (staggered 200ms)
+ * ───────────────────────────────────────────────────────── */
+
+const TIMING = {
+  cardAppear:  300,   // card fades in
+  heading:     900,   // heading highlights
+  rows:        1500,  // rows start staggering
+};
+```
+
+See [storyboard-animation.md](storyboard-animation.md) for the full pattern spec.
+
+### DialKit
+
+Generate live control panels for tuning values in real time:
+
+```tsx
+const params = useDialKit('Card', {
+  scale: [1, 0.5, 2],
+  blur: [0, 0, 100],
+  spring: { type: 'spring', visualDuration: 0.3, bounce: 0.2 },
+})
+```
+
+See [dialkit.md](dialkit.md) for all control types and patterns.
+
+## Sub-Skill Routing
+
+When the user invokes `/interface-craft`:
+
+1. **With `storyboard` argument or animation-related context** → Load and follow [storyboard-animation.md](storyboard-animation.md)
+2. **With `dialkit` argument or control-panel-related context** → Load and follow [dialkit.md](dialkit.md)
+3. **With `critique` argument, a pasted image, or review-related context** → Load and follow [design-critique.md](design-critique.md)
+4. **With a file path** → Read the file, detect whether it needs storyboard refactoring, dialkit controls, or a design critique, and apply the appropriate skill
+5. **With a plain-English description of an animation** → Use storyboard-animation to write it
+6. **Ambiguous** → Ask which skill to use
+
+## Design Principles
+
+1. **Readable over clever** — Anyone should be able to scan the top of a file and understand the animation sequence without reading implementation code
+2. **Tunable by default** — Every value that affects timing or appearance should be a named constant, trivially adjustable
+3. **Data-driven** — Repeated elements use arrays and `.map()`, not copy-pasted blocks
+4. **Stage-driven** — A single integer state drives the entire sequence; no scattered boolean flags
+5. **Spring-first** — Prefer spring physics over duration-based easing for natural motion

--- a/skills/interface-craft/design-critique.md
+++ b/skills/interface-craft/design-critique.md
@@ -1,0 +1,199 @@
+# Design Critique
+
+A systematic interface critique skill based on Josh Puckett's methodology from Interface Craft. Analyzes UI screenshots or component code and delivers specific, actionable feedback organized by visual design, interface design, interaction consistency, and user context.
+
+---
+
+## When to Use
+
+Trigger on: "critique", "review", "feedback", "audit", "what's wrong", "improve", "polish", "refine", "redesign", "analyze this UI", "look at this", or when the user pastes a screenshot/image for evaluation.
+
+---
+
+## Input Modes
+
+### 1. Image / Screenshot (Primary)
+The user pastes or attaches a screenshot. Read the image with the Read tool, then critique what you see.
+
+### 2. File Path (Secondary)
+The user provides a component file path. Read the file, mentally render the layout from the JSX/TSX, and critique the structural and stylistic decisions in the code. Note: you cannot see the rendered output, so focus on what's inferrable — layout structure, spacing patterns, color choices, typography, hierarchy, component organization, and interaction patterns.
+
+### 3. Live URL (Tertiary)
+The user provides a URL. Use WebFetch to retrieve the page content, then critique based on the markup and any screenshots the user provides.
+
+---
+
+## Critique Methodology
+
+Follow this sequence. Do NOT skip steps or merge them. Each section should feel like its own focused lens.
+
+### Step 0: Context
+
+Before critiquing, briefly establish:
+- **What is this?** (app type, screen purpose, target user)
+- **What emotional context surrounds this task?** (stressful? casual? high-stakes? routine?)
+
+This matters. A divorce filing app demands different care than a podcast player. Name the context so the critique respects it.
+
+### Step 1: First Impressions
+
+Spend one paragraph on gut reaction. What stands out? What feels off? What's the overall impression? Be honest and direct — not tentative.
+
+This is the "noticing" step. The skill of seeing what's actually in front of you, not what you expect to see.
+
+### Step 2: Visual Design
+
+Audit these specific dimensions:
+
+| Dimension | What to Look For |
+| --- | --- |
+| **Color intentionality** | Is every color used with purpose? Or are colors applied as decoration without meaning? Look for: too many background colors, competing accents, colors that don't establish hierarchy. |
+| **Typographic hierarchy** | Is there a clear scale from most important to least? Count the distinct sizes/weights. Are headlines distinguished from body from labels? Is there unnecessary repetition of type styles? |
+| **Shadow & stroke quality** | Are shadows crisp or muddy? Are strokes too prominent, competing with content? Do outlines/borders add structure or noise? |
+| **Visual weight vs. importance** | Do the visually heaviest elements match what's semantically most important? Or do decorative elements steal attention from primary actions? |
+| **Spacing & alignment** | Is spacing consistent? Are elements aligned to a clear grid? Is there excess padding pushing content away from where it should be? |
+| **Icon consistency** | Are icons from the same family? Same weight/stroke width? Same optical size? Or is it a mix of styles? |
+
+For each issue found, use this structure:
+> **[Issue name]** — [Specific factual observation]. [Impact on user or experience]. [What it could be instead.]
+
+Be precise. Count things. Quote text. Name colors. Measure relative sizes. "There are four distinct background colors competing for attention" is better than "too many colors."
+
+### Step 3: Interface Design
+
+Audit these dimensions:
+
+| Dimension | What to Look For |
+| --- | --- |
+| **Focusing mechanism** | Is it clear where the user should look first? Is there a visual entry point? Or does everything compete for attention equally? |
+| **Progressive disclosure** | Is complexity revealed gradually, or is everything dumped on the user at once? Are there 40 things on screen when 5 would suffice? |
+| **Information density** | Is the density appropriate for the context? Data dashboards can be dense; onboarding should not be. |
+| **Expectation setting** | Does the user know what will happen next? Is progress communicated? Is scope clear? |
+| **Feedback & reward** | Does the interface acknowledge user actions? Are completed items celebrated or just checked off? Is there a sense of forward momentum? |
+| **Redundancy** | Are labels, titles, or descriptions repeating information the user already knows? Can anything be removed without losing meaning? |
+
+Frame issues as missed opportunities:
+> "We're missing an opportunity to [reward progress / reduce cognitive load / set expectations / etc.]"
+
+### Step 4: Consistency & Conventions
+
+| Dimension | What to Look For |
+| --- | --- |
+| **Pattern consistency** | Are similar actions handled the same way throughout? Or do interaction patterns shift without reason? |
+| **Platform conventions** | Does the design follow established platform patterns (iOS, Android, web)? Deviations should be intentional improvements, not accidents. |
+| **Component reuse** | Are there elements that look like they should be the same component but aren't? Inconsistent card styles, button treatments, list items? |
+| **Visual language cohesion** | Does the interface feel like one designer made it? Or does it feel assembled from different kits? |
+
+### Step 5: User Context
+
+This is where empathy meets analysis:
+
+- **How does this design make the user feel?** Name the emotion. "Overwhelmed," "confused," "unsupported," "rushed."
+- **What is the user's likely state of mind?** Anxious? Focused? Browsing casually? Under time pressure?
+- **Does the interface respect that state?** Or does it add unnecessary cognitive burden?
+- **What would "uncommon care" look like here?** What would surprise the user with thoughtfulness?
+
+---
+
+## Output Format
+
+Structure the critique as:
+
+```
+## Context
+[1-2 sentences on what this is and who it's for]
+
+## First Impressions
+[1 paragraph, direct and honest]
+
+## Visual Design
+[Each issue as: **Issue Name** — observation. Impact. Opportunity.]
+
+## Interface Design
+[Each issue framed as missed opportunities]
+
+## Consistency & Conventions
+[Pattern and convention issues]
+
+## User Context
+[Empathy-driven observations]
+
+## Top Opportunities
+[Ranked list of the 3-5 highest-impact changes, each in one sentence]
+```
+
+---
+
+## Voice Rules
+
+Follow these strictly. They define the critique style.
+
+### BE:
+- **Specific** — "There are six columns of data per row" not "there's a lot of data"
+- **Decisive** — "This is overwhelming" not "this might feel overwhelming"
+- **Factual first** — State what you see before judging it
+- **Impact-aware** — Always connect the observation to how it affects the user
+- **Constructive** — Every problem gets paired with an opportunity or direction
+- **Quantitative** — Count elements, name colors, measure relative sizes
+
+### DO NOT:
+- **Hedge** — No "maybe," "perhaps," "it could be argued that"
+- **Apologize** — No "unfortunately" or "sadly"
+- **Be vague** — No "the design feels off" without saying exactly what and why
+- **Prescribe without reasoning** — Never say "change X to Y" without explaining the why
+- **Add praise padding** — Don't sandwich criticism with empty compliments. If something works well, say so specifically. But don't manufacture positivity.
+- **Use jargon without explanation** — "Progressive disclosure" is fine. "The affordance signifiers lack semiotic clarity" is not.
+
+### Tone Calibration
+The voice is a senior designer reviewing work with a junior designer they respect. Direct, analytical, and honest — but rooted in wanting the work to be great. No cruelty, no condescension, but also no hand-holding. The goal is to make the designer *see* what you see.
+
+---
+
+## Severity Guide
+
+Not all issues are equal. When listing issues, implicitly order by impact:
+
+1. **Structural** — Problems with information architecture, missing functionality, wrong mental model. These change what the interface *is*.
+2. **Behavioral** — Problems with how the interface responds, flows, or communicates. These change how the interface *feels*.
+3. **Visual** — Problems with color, type, spacing, shadows. These change how the interface *looks*.
+
+A structural issue (wrong mental model for a divorce app) matters more than a visual one (shadow is slightly muddy). Prioritize accordingly.
+
+---
+
+## Frameworks to Reference
+
+These are the conceptual tools behind the critique. You don't need to name them explicitly, but they should inform your analysis:
+
+### Noticing
+The foundation. Most people glance; good designers see. Count the elements. Name the colors. Measure the spacing. The specificity of your observation is the quality of your critique.
+
+### Industry Standards
+Every popular app in a category sets an invisible bar. Users carry those expectations into every new app. A notes app is compared to Apple Notes, Bear, Notion. A dashboard is compared to Stripe, Linear, Vercel. If the design falls below the bar users already carry, it feels amateur — even if the user can't articulate why.
+
+Ask: "What would [best-in-class app in this category] do here?"
+
+### Facets of Quality
+Quality isn't one thing. It's a collection of attributes. For any given interface, identify which 3-5 attributes matter most. Not every app needs to be "playful" — but every app needs to be clear about what it values and execute on those values consistently.
+
+### Uncommon Care
+The difference between good and great is often invisible to people who haven't seen great. Look for moments where the designer could have gone further — micro-interactions, empty states, error messages, transitions, loading states, edge cases. These are where "uncommon care" lives.
+
+### Separation of Concerns
+Visual design, interface design, and interaction design are different skills solving different problems. A beautiful interface can be unusable. A usable interface can be ugly. Critique each dimension on its own terms before synthesizing.
+
+---
+
+## Examples of Good Critique Language
+
+**Visual:**
+> **Muddy shadows** — The card shadows use a large blur radius with low opacity, creating a hazy, unfocused look rather than crisp depth. This makes the cards feel like they're floating in fog rather than sitting on a surface. Tighter, more directional shadows would give the layout a cleaner sense of elevation.
+
+**Interface:**
+> **No focusing mechanism** — All four content areas compete equally for attention. There's no visual entry point — no element says "start here." The user's eye bounces between the sidebar, the header stats, the chart, and the table with no clear priority. A stronger size or weight differential on the primary content area would give the layout a clear narrative.
+
+**User context:**
+> **Demoralizing progress display** — Showing "10 / 47 tasks complete" immediately communicates that 37 tasks remain. For a process that takes weeks and involves one of the most stressful experiences in a person's life, this is demoralizing. "Complete Phase 1 of 4" is psychologically very different — it frames the same progress as achievable milestones rather than an endless checklist.
+
+**Opportunity:**
+> We're missing a huge opportunity to reward progress. Completed steps could collapse or fade, making the remaining work feel smaller — not larger — as the user advances.

--- a/skills/interface-craft/dialkit.md
+++ b/skills/interface-craft/dialkit.md
@@ -1,0 +1,260 @@
+# DialKit
+
+**Part of [Interface Craft](SKILL.md) by Josh Puckett**
+
+Generate DialKit configurations for React + Motion projects — live control panels for tuning animation and style values in real time.
+
+---
+
+## When to use
+
+- User mentions DialKit, dials, sliders, controls, tune, tweak
+- User wants a live UI to adjust animation parameters
+- User says "add controls for..." or "let me tune..."
+
+## Mode Detection
+
+### Direct Mode
+Triggers when user describes what they want with context:
+- "use DialKit to give me sliders for blur and opacity"
+- "add dialkit controls for scale, rotation, and a spring"
+- "I need toggles and sliders for my card animation"
+
+In direct mode, generate the config immediately based on the request.
+
+### Guided Mode
+Triggers when user invokes without specific context or asks for help:
+- `/interface-craft dialkit`
+- "help me set up dialkit"
+- "walk me through adding dialkit"
+
+In guided mode, ask 2-3 concise questions then generate.
+
+## Setup Check
+
+Before generating configs, verify DialKit is installed. If working in a project:
+
+1. Check if `dialkit` is in package.json dependencies
+2. If not installed, provide:
+```bash
+npm install dialkit motion
+```
+
+3. Check if DialRoot is set up in a layout file. If not, remind user:
+```tsx
+import { DialRoot } from 'dialkit'
+import 'dialkit/styles.css'
+
+// Add to your root layout:
+<DialRoot position="top-right" />
+```
+
+## Guided Flow Questions
+
+Keep it fast - 2-3 questions max:
+
+1. **Component context**: "What component are you adding controls to? Share the code or describe what you're building."
+
+2. **Property selection**: "What properties do you want to tweak? Common options:
+   - **Visual**: blur, opacity, scale, borderRadius
+   - **Position**: offsetX, offsetY, rotation
+   - **Animation**: spring (with visualDuration/bounce controls)
+   - **Interaction**: action buttons, toggles"
+
+3. Generate with smart defaults - don't ask about ranges.
+
+## Smart Defaults
+
+Use these defaults for common properties (users can adjust in the panel):
+
+| Property | Default | Min | Max | Step |
+|----------|---------|-----|-----|------|
+| blur | 0 | 0 | 100 | 1 |
+| opacity | 1 | 0 | 1 | 0.01 |
+| scale | 1 | 0.5 | 2 | 0.1 |
+| rotation | 0 | -180 | 180 | 1 |
+| offsetX | 0 | -100 | 100 | 1 |
+| offsetY | 0 | -100 | 100 | 1 |
+| borderRadius | 0 | 0 | 50 | 1 |
+| shadowBlur | 16 | 0 | 48 | 1 |
+| shadowOffsetY | 8 | 0 | 24 | 1 |
+| gap | 16 | 0 | 48 | 1 |
+| padding | 16 | 0 | 48 | 1 |
+
+## Control Types
+
+See [references/config-patterns.json](references/config-patterns.json) for the full schema. Summary:
+
+### 1. Slider (explicit range)
+```tsx
+blur: [24, 0, 100]  // [default, min, max]
+```
+
+### 2. Slider (auto-inferred)
+```tsx
+scale: 1.18  // auto-infers range based on value
+```
+
+### 3. Toggle
+```tsx
+visible: true
+```
+
+### 4. Spring (Time mode - simpler)
+```tsx
+spring: {
+  type: 'spring',
+  visualDuration: 0.3,
+  bounce: 0.2,
+}
+```
+
+### 5. Spring (Physics mode - more control)
+```tsx
+spring: {
+  type: 'spring',
+  stiffness: 200,
+  damping: 25,
+  mass: 1,
+}
+```
+
+### 6. Action Button
+```tsx
+reset: { type: 'action' }
+next: { type: 'action', label: 'Next Slide' }
+```
+
+### 7. Select Dropdown
+```tsx
+theme: {
+  type: 'select',
+  options: ['light', 'dark', 'system'],
+  default: 'system',
+}
+```
+
+### 8. Color Picker
+```tsx
+backgroundColor: { type: 'color', default: '#3b82f6' }
+// or auto-detected from hex string:
+accentColor: '#3b82f6'
+```
+
+### 9. Text Input
+```tsx
+title: { type: 'text', default: 'Hello', placeholder: 'Enter title...' }
+// or auto-detected from plain string:
+label: 'Click me'
+```
+
+### 10. Folder (nested grouping)
+```tsx
+shadow: {
+  offsetY: [8, 0, 24],
+  blur: [16, 0, 48],
+  opacity: [0.2, 0, 1],
+}
+```
+
+## Output Format
+
+Always generate complete, copy-paste ready code:
+
+```tsx
+import { useDialKit } from 'dialkit'
+import { motion } from 'motion/react'
+
+function ComponentName() {
+  const params = useDialKit('ComponentName', {
+    // Generated config here
+  })
+
+  return (
+    <motion.div
+      style={{
+        // Apply params
+      }}
+      animate={{
+        // Animate params
+      }}
+      transition={params.spring}
+    />
+  )
+}
+```
+
+## Example Generations
+
+### Request: "sliders for blur and opacity"
+```tsx
+const params = useDialKit('Effects', {
+  blur: [0, 0, 100],
+  opacity: [1, 0, 1],
+})
+
+// Usage:
+style={{
+  filter: `blur(${params.blur}px)`,
+  opacity: params.opacity,
+}}
+```
+
+### Request: "spring animation with scale"
+```tsx
+const params = useDialKit('Animation', {
+  scale: [1, 0.5, 2],
+  spring: {
+    type: 'spring',
+    visualDuration: 0.3,
+    bounce: 0.2,
+  },
+})
+
+// Usage:
+animate={{ scale: params.scale }}
+transition={params.spring}
+```
+
+### Request: "card with shadow controls"
+```tsx
+const params = useDialKit('Card', {
+  borderRadius: [16, 0, 50],
+  shadow: {
+    offsetY: [8, 0, 24],
+    blur: [16, 0, 48],
+    opacity: [0.2, 0, 1],
+  },
+})
+
+// Usage:
+style={{
+  borderRadius: params.borderRadius,
+  boxShadow: `0 ${params.shadow.offsetY}px ${params.shadow.blur}px rgba(0,0,0,${params.shadow.opacity})`,
+}}
+```
+
+### Request: "controls with actions"
+```tsx
+const params = useDialKit('Slideshow', {
+  autoPlay: true,
+  interval: [3, 1, 10],
+  next: { type: 'action' },
+  prev: { type: 'action' },
+  reset: { type: 'action' },
+}, {
+  onAction: (action) => {
+    if (action === 'next') goNext()
+    if (action === 'prev') goPrev()
+    if (action === 'reset') reset()
+  },
+})
+```
+
+## Tips for Generation
+
+1. **Infer panel name** from component name or context
+2. **Group related controls** in nested objects (folders)
+3. **Use Time mode springs** by default (simpler for most users)
+4. **Include usage comments** showing how to apply each param
+5. **Match user's coding style** if they shared code

--- a/skills/interface-craft/references/config-patterns.json
+++ b/skills/interface-craft/references/config-patterns.json
@@ -1,0 +1,208 @@
+{
+  "controlTypes": {
+    "slider": {
+      "description": "Numeric slider control",
+      "formats": [
+        {
+          "syntax": "[default, min, max]",
+          "example": "blur: [24, 0, 100]",
+          "description": "Explicit range tuple"
+        },
+        {
+          "syntax": "number",
+          "example": "scale: 1.18",
+          "description": "Auto-inferred range based on value"
+        }
+      ],
+      "usage": "Returns number value directly: params.blur"
+    },
+    "toggle": {
+      "description": "Boolean on/off switch",
+      "formats": [
+        {
+          "syntax": "boolean",
+          "example": "visible: true",
+          "description": "Boolean value creates toggle"
+        }
+      ],
+      "usage": "Returns boolean: params.visible"
+    },
+    "spring": {
+      "description": "Visual spring curve editor with live preview",
+      "formats": [
+        {
+          "syntax": "{ type: 'spring', visualDuration, bounce }",
+          "example": "spring: { type: 'spring', visualDuration: 0.3, bounce: 0.2 }",
+          "description": "Time mode - simpler, recommended for most cases"
+        },
+        {
+          "syntax": "{ type: 'spring', stiffness, damping, mass }",
+          "example": "spring: { type: 'spring', stiffness: 200, damping: 25, mass: 1 }",
+          "description": "Physics mode - more control over spring behavior"
+        }
+      ],
+      "usage": "Returns SpringConfig object: transition={params.spring}",
+      "defaults": {
+        "time": { "visualDuration": 0.3, "bounce": 0.2 },
+        "physics": { "stiffness": 200, "damping": 25, "mass": 1 }
+      }
+    },
+    "action": {
+      "description": "Button that triggers callback",
+      "formats": [
+        {
+          "syntax": "{ type: 'action' }",
+          "example": "reset: { type: 'action' }",
+          "description": "Basic action button using key as label"
+        },
+        {
+          "syntax": "{ type: 'action', label: string }",
+          "example": "next: { type: 'action', label: 'Next Slide' }",
+          "description": "Action with custom label"
+        }
+      ],
+      "usage": "Requires onAction callback in options: onAction: (action) => { if (action === 'reset') handleReset() }"
+    },
+    "select": {
+      "description": "Dropdown select control",
+      "formats": [
+        {
+          "syntax": "{ type: 'select', options: string[], default?: string }",
+          "example": "theme: { type: 'select', options: ['light', 'dark'], default: 'dark' }",
+          "description": "Simple string options"
+        },
+        {
+          "syntax": "{ type: 'select', options: { value, label }[] }",
+          "example": "size: { type: 'select', options: [{ value: 'sm', label: 'Small' }, { value: 'lg', label: 'Large' }] }",
+          "description": "Options with separate value and display label"
+        }
+      ],
+      "usage": "Returns selected value as string: params.theme"
+    },
+    "color": {
+      "description": "Color picker control",
+      "formats": [
+        {
+          "syntax": "{ type: 'color', default?: string }",
+          "example": "bgColor: { type: 'color', default: '#3b82f6' }",
+          "description": "Explicit color config"
+        },
+        {
+          "syntax": "string (hex format)",
+          "example": "accentColor: '#3b82f6'",
+          "description": "Auto-detected from hex string (#RGB, #RRGGBB, or #RRGGBBAA)"
+        }
+      ],
+      "usage": "Returns hex color string: params.bgColor"
+    },
+    "text": {
+      "description": "Text input control",
+      "formats": [
+        {
+          "syntax": "{ type: 'text', default?: string, placeholder?: string }",
+          "example": "title: { type: 'text', default: 'Hello', placeholder: 'Enter title...' }",
+          "description": "Explicit text config"
+        },
+        {
+          "syntax": "string (non-hex)",
+          "example": "label: 'Click me'",
+          "description": "Auto-detected from plain string"
+        }
+      ],
+      "usage": "Returns string value: params.title"
+    },
+    "folder": {
+      "description": "Collapsible group for organizing controls",
+      "formats": [
+        {
+          "syntax": "{ nested: DialConfig }",
+          "example": "shadow: { offsetY: [8, 0, 24], blur: [16, 0, 48] }",
+          "description": "Nested object creates folder"
+        }
+      ],
+      "usage": "Access nested values: params.shadow.offsetY"
+    }
+  },
+  "smartDefaults": {
+    "blur": { "default": 0, "min": 0, "max": 100, "step": 1 },
+    "opacity": { "default": 1, "min": 0, "max": 1, "step": 0.01 },
+    "scale": { "default": 1, "min": 0.5, "max": 2, "step": 0.1 },
+    "rotation": { "default": 0, "min": -180, "max": 180, "step": 1 },
+    "rotate": { "default": 0, "min": -180, "max": 180, "step": 1 },
+    "offsetX": { "default": 0, "min": -100, "max": 100, "step": 1 },
+    "offsetY": { "default": 0, "min": -100, "max": 100, "step": 1 },
+    "x": { "default": 0, "min": -100, "max": 100, "step": 1 },
+    "y": { "default": 0, "min": -100, "max": 100, "step": 1 },
+    "borderRadius": { "default": 0, "min": 0, "max": 50, "step": 1 },
+    "shadowBlur": { "default": 16, "min": 0, "max": 48, "step": 1 },
+    "shadowOffsetY": { "default": 8, "min": 0, "max": 24, "step": 1 },
+    "shadowOpacity": { "default": 0.2, "min": 0, "max": 1, "step": 0.01 },
+    "gap": { "default": 16, "min": 0, "max": 48, "step": 1 },
+    "padding": { "default": 16, "min": 0, "max": 48, "step": 1 },
+    "width": { "default": 200, "min": 50, "max": 500, "step": 1 },
+    "height": { "default": 200, "min": 50, "max": 500, "step": 1 },
+    "delay": { "default": 0, "min": 0, "max": 2, "step": 0.1 },
+    "duration": { "default": 0.3, "min": 0, "max": 2, "step": 0.1 },
+    "stagger": { "default": 0.1, "min": 0, "max": 0.5, "step": 0.01 }
+  },
+  "typeDefinitions": {
+    "SpringConfig": "{ type: 'spring'; stiffness?: number; damping?: number; mass?: number; visualDuration?: number; bounce?: number }",
+    "ActionConfig": "{ type: 'action'; label?: string }",
+    "SelectConfig": "{ type: 'select'; options: (string | { value: string; label: string })[]; default?: string }",
+    "ColorConfig": "{ type: 'color'; default?: string }",
+    "TextConfig": "{ type: 'text'; default?: string; placeholder?: string }",
+    "DialValue": "number | boolean | string | SpringConfig | ActionConfig | SelectConfig | ColorConfig | TextConfig",
+    "DialConfig": "{ [key: string]: DialValue | [number, number, number] | DialConfig }"
+  },
+  "commonPatterns": {
+    "fadeIn": {
+      "description": "Fade in animation controls",
+      "config": {
+        "opacity": [0, 0, 1],
+        "spring": { "type": "spring", "visualDuration": 0.4, "bounce": 0 }
+      }
+    },
+    "scaleUp": {
+      "description": "Scale up animation controls",
+      "config": {
+        "scale": [0.9, 0.5, 1.5],
+        "spring": { "type": "spring", "visualDuration": 0.3, "bounce": 0.2 }
+      }
+    },
+    "slideIn": {
+      "description": "Slide in animation controls",
+      "config": {
+        "offsetY": [20, -100, 100],
+        "opacity": [0, 0, 1],
+        "spring": { "type": "spring", "visualDuration": 0.4, "bounce": 0.1 }
+      }
+    },
+    "cardShadow": {
+      "description": "Card shadow controls",
+      "config": {
+        "shadow": {
+          "offsetY": [8, 0, 24],
+          "blur": [16, 0, 48],
+          "opacity": [0.2, 0, 1]
+        }
+      }
+    },
+    "glassEffect": {
+      "description": "Glassmorphism effect controls",
+      "config": {
+        "blur": [16, 0, 48],
+        "opacity": [0.8, 0, 1],
+        "borderRadius": [16, 0, 50]
+      }
+    },
+    "hoverCard": {
+      "description": "Interactive hover card controls",
+      "config": {
+        "scale": [1, 0.95, 1.1],
+        "shadowBlur": [8, 0, 32],
+        "shadowOffsetY": [4, 0, 16],
+        "spring": { "type": "spring", "visualDuration": 0.2, "bounce": 0.1 }
+      }
+    }
+  }
+}

--- a/skills/interface-craft/storyboard-animation.md
+++ b/skills/interface-craft/storyboard-animation.md
@@ -1,0 +1,198 @@
+# Storyboard Animation
+
+**Part of [Interface Craft](SKILL.md) by Josh Puckett**
+
+A pattern for writing and refactoring React animations into a human-readable storyboard format. Every timing value, scale, position, and spring config is extracted to named constants at the top of the file so you can read the animation like a script and tune any value instantly.
+
+---
+
+## When to use
+
+- User says "animate", "transition", "entrance animation", "storyboard", etc.
+- User pastes existing animation code and wants it cleaned up
+- User describes a desired animation in plain English
+- User points to a file with `motion.*` components that have inline timing/values
+
+## The Storyboard Pattern
+
+Every animated component follows this exact structure:
+
+### 1. ASCII Storyboard Comment
+
+A block comment at the top of the file that reads like a shot list. Anyone can scan it and understand the full sequence without reading code.
+
+```
+/* ─────────────────────────────────────────────────────────
+ * ANIMATION STORYBOARD
+ *
+ * Read top-to-bottom. Each `at` value is ms after trigger.
+ *
+ *    0ms   waiting for trigger (scroll into view / mount)
+ *  300ms   card fades in, scale 0.85 → 1.0
+ *  900ms   heading text highlights
+ * 1500ms   detail rows slide up (staggered 200ms)
+ * 2100ms   CTA button fades in
+ * ───────────────────────────────────────────────────────── */
+```
+
+Rules for the storyboard comment:
+- Right-align the ms values for scannability
+- Use `→` to show value transitions (e.g. `scale 0.8 → 1.5`)
+- Note stagger intervals in parentheses
+- Keep descriptions short — one line per stage
+
+### 2. TIMING Object
+
+A single `const TIMING` object with every stage delay in milliseconds. This is the **only place** timing values live.
+
+```tsx
+const TIMING = {
+  cardAppear:    300,   // card fades in and scales up
+  headingGlow:   900,   // heading text highlights
+  detailRows:    1500,  // rows start staggering in
+  ctaButton:     2100,  // button fades in
+};
+```
+
+Rules:
+- Keys are `camelCase`, descriptive verb phrases
+- Values are ms after the animation trigger (not deltas between stages)
+- Every key gets an inline comment
+- Align values and comments for readability
+
+### 3. Element Config Objects
+
+Each animated element (or group of elements) gets its own named config object with all its visual values and spring config.
+
+```tsx
+/* Card container */
+const CARD = {
+  initialScale: 0.85,   // scale before appearing
+  finalScale:   1.0,     // resting scale
+  spring: { type: "spring" as const, stiffness: 300, damping: 30 },
+};
+
+/* Detail rows */
+const ROWS = {
+  stagger:  0.2,   // seconds between each row
+  offsetY:  12,    // px each row slides up from
+  spring: { type: "spring" as const, stiffness: 300, damping: 30 },
+  items: [
+    { label: "Row 1", value: "A" },
+    { label: "Row 2", value: "B" },
+  ],
+};
+```
+
+Rules:
+- UPPERCASE name matching the element it controls
+- Group ALL values for one element together — scales, positions, colors, springs
+- Repeated items are arrays inside the config, rendered with `.map()`
+- Spring configs live here, never inline in JSX
+- Every value gets a short comment
+
+### 4. Component Body
+
+```tsx
+export function MyFigure({ replayTrigger = 0 }: { replayTrigger?: number }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const isInView = useInView(ref, { once: true, margin: "-100px" });
+  const [stage, setStage] = useState(0);
+
+  useEffect(() => {
+    if (!isInView) { setStage(0); return; }
+
+    setStage(0);
+    const timers: NodeJS.Timeout[] = [];
+
+    timers.push(setTimeout(() => setStage(1), TIMING.cardAppear));
+    timers.push(setTimeout(() => setStage(2), TIMING.headingGlow));
+    timers.push(setTimeout(() => setStage(3), TIMING.detailRows));
+    timers.push(setTimeout(() => setStage(4), TIMING.ctaButton));
+
+    return () => timers.forEach(clearTimeout);
+  }, [isInView, replayTrigger]);
+
+  return ( /* JSX using stage >= N and config values */ );
+}
+```
+
+Rules:
+- Single `stage` state integer (not multiple booleans)
+- One `useEffect` with all `setTimeout` calls reading from `TIMING`
+- Cleanup clears all timers
+- `replayTrigger` prop in dependency array enables click-to-replay
+- JSX references config objects: `CARD.initialScale`, not `0.85`
+- Stage checks in animate: `stage >= 1 ? CARD.finalScale : CARD.initialScale`
+
+### 5. JSX Pattern for `motion.*` Elements
+
+```tsx
+<motion.div
+  initial={{
+    opacity: 0,
+    scale: CARD.initialScale,
+  }}
+  animate={{
+    opacity: stage >= 1 ? 1 : 0,
+    scale:   stage >= 1 ? CARD.finalScale : CARD.initialScale,
+  }}
+  transition={CARD.spring}
+>
+```
+
+For staggered groups:
+```tsx
+{ROWS.items.map((item, i) => (
+  <motion.div
+    key={item.label}
+    initial={{ opacity: 0, y: ROWS.offsetY }}
+    animate={{
+      opacity: stage >= 3 ? 1 : 0,
+      y:       stage >= 3 ? 0 : ROWS.offsetY,
+    }}
+    transition={{ ...ROWS.spring, delay: i * ROWS.stagger }}
+  >
+    {item.label}
+  </motion.div>
+))}
+```
+
+---
+
+## How to apply
+
+### Refactoring existing code
+
+When the user provides a file or code with animations:
+
+1. **Read the code** and identify every animated element and its timing
+2. **Extract** all magic numbers (delays, scales, positions, springs) into config objects
+3. **Write the storyboard comment** describing the sequence in plain English
+4. **Create the TIMING object** with all stage delays
+5. **Create element config objects** grouping values by animated element
+6. **Rewrite the component** using the stage pattern
+7. **Replace repeated elements** with data-driven `.map()` where applicable
+
+### Writing new animations from a description
+
+When the user describes what they want:
+
+1. **Parse the description** into discrete stages with approximate timing
+2. **Write the storyboard comment first** — confirm the sequence with the user if unclear
+3. **Define TIMING** with sensible defaults (300ms initial delay, 500-700ms between stages)
+4. **Define element configs** with appropriate springs:
+   - Cards/containers: `{ stiffness: 300, damping: 30 }` (smooth settle)
+   - Pop-ins/badges: `{ stiffness: 500, damping: 25 }` (snappy)
+   - Slides/entrances: `{ stiffness: 350, damping: 28 }` (balanced)
+5. **Build the component** following the pattern above
+
+### Quick checklist
+
+Before finishing, verify:
+- [ ] Storyboard comment at top matches the actual TIMING values
+- [ ] Zero magic numbers in JSX or useEffect — everything references a const
+- [ ] Springs defined in config objects, not inline
+- [ ] Repeated elements use `.map()` over a data array
+- [ ] Stage values in JSX are `>=` checks (allows stages to be additive)
+- [ ] `replayTrigger` in the dependency array for dev/debug replay support

--- a/skills/storyboard-animation.md
+++ b/skills/storyboard-animation.md
@@ -1,0 +1,166 @@
+---
+name: storyboard-animation
+description: "Turn multi-step animations into readable scripts. ASCII storyboard at top, TIMING object for delays, element config objects for scales/positions/springs, single stage integer drives sequence. Motion/Framer Motion pattern."
+metadata:
+  author: raphael-salaja (forked + refactored for ProductionOS)
+  version: "1.0.0"
+  filePattern: "**/*.tsx,**/*.jsx,**/components/**,**/animations/**"
+  bashPattern: "motion|framer-motion|animate"
+  priority: 80
+---
+
+# Storyboard Animation Skill
+
+Turns multi-step animations into something you can read like a script. Every timing value, scale, position, and spring config gets extracted to named constants at the top. A single stage integer drives the whole sequence.
+
+## When to Use
+
+- Building any multi-step staged animation
+- Implementing entrance/exit sequences
+- Creating scroll-triggered animation chains
+- When user describes an animation in plain English
+
+## The Pattern (4 parts)
+
+### Part 1: ASCII Storyboard
+
+Every animated component starts with an ASCII storyboard comment. Read top-to-bottom like a shot list.
+
+```tsx
+/* ────────────────────────────────────────────────
+ * ANIMATION STORYBOARD
+ *
+ * Read top-to-bottom. Each `at` is ms after trigger.
+ *
+ *     0ms    idle / waiting
+ *   300ms    element A fades in, scale 0.8 → 1.0
+ *   800ms    element A slides to final position
+ *  1200ms    elements B pop in (staggered 50ms)
+ *  2000ms    sequence complete
+ * ──────────────────────────────────────────────── */
+```
+
+Rules:
+- One line per visual change
+- Include scale/position transitions with arrows (→)
+- Include stagger timing for groups
+- Comments mirror the TIMING object below
+
+### Part 2: TIMING Object
+
+Single object holds every delay. This is the ONLY place timing values live.
+
+```tsx
+const TIMING = {
+  elementAAppear:  300,   // A fades in, springs to scale
+  elementASlide:   800,   // A moves to final position
+  groupBAppear:   1200,   // B items start popping in
+};
+```
+
+Rules:
+- Comments mirror the storyboard
+- All values in milliseconds
+- Never hardcode timing elsewhere in the component
+
+### Part 3: Element Config Objects
+
+Each animated element gets its own config. Scales, positions, springs grouped together.
+
+```tsx
+const ELEMENT_A = {
+  initialScale:  0.8,
+  finalScale:    1.0,
+  initialTop:    "50%",
+  finalTop:      "24px",
+  spring: { type: "spring" as const, stiffness: 250, damping: 25 },
+};
+
+const GROUP_B = {
+  stagger: 0.05,  // seconds between items
+  spring: { type: "spring" as const, stiffness: 500, damping: 25 },
+  items: [
+    { label: "Item 1", className: "left-[10%] top-[20%]" },
+    { label: "Item 2", className: "right-[15%] top-[40%]" },
+  ],
+};
+```
+
+Rules:
+- Group ALL visual properties for one element together
+- Include spring config with the element, not separately
+- Stagger values in seconds (Motion convention)
+- Use `as const` for type safety on spring type
+
+### Part 4: Stage Pattern
+
+Single `stage` integer drives the sequence. No boolean flags or nested conditionals.
+
+```tsx
+const [stage, setStage] = useState(0);
+
+useEffect(() => {
+  const timers = [
+    setTimeout(() => setStage(1), TIMING.elementAAppear),
+    setTimeout(() => setStage(2), TIMING.elementASlide),
+    setTimeout(() => setStage(3), TIMING.groupBAppear),
+  ];
+  return () => timers.forEach(clearTimeout);
+}, []);
+
+// In JSX:
+<motion.div
+  animate={{
+    opacity: stage >= 1 ? 1 : 0,
+    scale:   stage >= 2 ? ELEMENT_A.finalScale : ELEMENT_A.initialScale,
+    top:     stage >= 2 ? ELEMENT_A.finalTop : ELEMENT_A.initialTop,
+  }}
+  transition={ELEMENT_A.spring}
+/>
+
+{GROUP_B.items.map((item, i) => (
+  <motion.div
+    key={item.label}
+    className={item.className}
+    animate={{
+      opacity: stage >= 3 ? 1 : 0,
+      scale:   stage >= 3 ? 1 : 0,
+    }}
+    transition={{ ...GROUP_B.spring, delay: i * GROUP_B.stagger }}
+  />
+))}
+```
+
+Rules:
+- `stage >= N` checks in animate props (not `stage === N`)
+- This allows cumulative animations (stage 3 includes stage 1+2 effects)
+- useEffect with TIMING constants drives the sequence
+- Clean up all timeouts on unmount
+
+## Spring Parameter Guide (from userinterface-wiki)
+
+| Use Case | Stiffness | Damping | Notes |
+|----------|-----------|---------|-------|
+| UI element entrance | 250-350 | 20-30 | Smooth settle |
+| Snappy pop-in (tags, markers) | 400-600 | 20-30 | Quick, decisive |
+| Gesture follow (drag, flick) | 150-250 | 15-25 | Preserves velocity |
+| Bounce effect | 300-400 | 10-15 | Low damping = more bounce |
+| Micro-interaction (hover) | 500-700 | 30-40 | Barely perceptible |
+
+**Critical rules:**
+- Stagger: under 50ms per item (avoid excessive stagger)
+- Duration: NEVER exceed 300ms for user-initiated animations
+- Press/hover: 120-180ms
+- Small state changes: 180-260ms
+
+## Combining with DialKit
+
+For live tuning during development:
+```
+Build [description]. Use the storyboard animation pattern
+and add DialKit controls for the spring, timing delays,
+and key position values.
+```
+
+## Output
+Storyboard components go in the component's file with all constants at the top.


### PR DESCRIPTION
## Summary

- Install and integrate **interface-craft** (Josh Puckett / interfacecraft.dev) as native ProductionOS skills
- Install **userinterface-wiki** (Raphael Salaja) — 152 UI rules across 12 categories
- Enrich `designer-upgrade` agent with full motion system, design critique methodology, and live tuning capabilities

## Skills Added

| Skill | Source | Content |
|-------|--------|---------|
| `interface-craft` | interfacecraft.dev | Storyboard Animation + DialKit + Design Critique |
| `design-critique` | Forked from interface-craft | 4-lens review methodology |
| `storyboard-animation` | Forked from interface-craft | ASCII storyboard + stage-driven animation DSL |
| `dialkit-live-tuning` | Forked from interface-craft | Real-time parameter tuning with useDialKit |

## designer-upgrade Enrichments

- Motion system: duration scale, easing decisions, spring parameters (from userinterface-wiki)
- Phase 2.5: Animation Architecture (storyboard pattern before mockup generation)
- Visual design rules: concentric radius, layered shadows, alpha borders
- Typography rules: tabular nums, text-wrap balance, font-display swap
- UX laws: Fitts's, Doherty, Jakob's, progressive disclosure
- Design critique: 4-lens + micro-refinement patterns from "Refining Today"
- 4 few-shot examples for orchestrator invocation
- Reference sites: interfacecraft.dev, userinterface.wiki, calligraph

## Test plan
- [ ] Run `/designer-upgrade` on a test frontend project
- [ ] Verify storyboard animation skill generates correct ASCII + TIMING pattern
- [ ] Verify design critique produces 4-lens structured output
- [ ] Verify DialKit integration generates useDialKit hook code

Generated with [Claude Code](https://claude.com/claude-code)