### PR TITLE
fix(ci): remove 4 unused imports — root cause of all 16 CI failures

### DIFF
--- a/scripts/agent-index.ts
+++ b/scripts/agent-index.ts
@@ -17,7 +17,7 @@
 
 import { readFileSync, writeFileSync, existsSync, statSync, readdirSync, mkdirSync } from "fs";
 import { join } from "path";
-import { ROOT, parseFrontmatter, readFileOrNull } from "./lib/shared";
+import { ROOT, parseFrontmatter } from "./lib/shared";
 
 // ─── Types ──────────────────────────────────────────────────
 

--- a/scripts/stack-detector.ts
+++ b/scripts/stack-detector.ts
@@ -10,7 +10,7 @@
  */
 
 import { existsSync, readFileSync } from "fs";
-import { join, basename } from "path";
+import { join } from "path";
 
 // ─── Types ──────────────────────────────────────────────────
 

--- a/tests/agent-index.test.ts
+++ b/tests/agent-index.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { scanAgents, classifyIntent, getAgentIndex } from "../scripts/agent-index";
+import { classifyIntent, getAgentIndex } from "../scripts/agent-index";
 
 describe("agent-index", () => {
   const { agents } = getAgentIndex();

--- a/tests/stack-detector.test.ts
+++ b/tests/stack-detector.test.ts
@@ -1,6 +1,5 @@
 import { describe, test, expect } from "bun:test";
 import { detectStack } from "../scripts/stack-detector";
-import { join } from "path";
 
 const ROOT = new URL("../", import.meta.url).pathname.replace(/\/$/, "");
 


### PR DESCRIPTION
Root cause: 4 unused TypeScript imports introduced in PR #65 (Production House Phase 1).

Every CI run since PR #63 has failed with the same 4 TS6133 errors:
- `readFileOrNull` in agent-index.ts
- `basename` in stack-detector.ts
- `scanAgents` in agent-index.test.ts
- `join` in stack-detector.test.ts

Generated with [Claude Code](https://claude.com/claude-code)