### PR TITLE
fix: quickstart install flow + hook reliability

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,12 +1,12 @@
 {
-  "name": "productionos",
+  "name": "productupgrade",
   "owner": {
     "name": "ProductionOS Contributors",
     "url": "https://github.com/ShaheerKhawaja/ProductionOS"
   },
   "plugins": [
     {
-      "name": "productionos",
+      "name": "productupgrade",
       "description": "AI engineering OS for Claude Code — 76 agents, 39 commands, 12 hooks. Smart routing + adaptive learning + dynamic agent factory.",
       "version": "1.0.0-beta.1",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "productionos",
+  "name": "productupgrade",
   "description": "AI engineering OS for Claude Code — 76 agents, 39 commands, 12 hooks. 4-layer Production House: smart routing, adaptive learning, dynamic agent factory. Zero external dependencies.",
   "version": "1.0.0-beta.1",
   "author": {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ ProductionOS is a Claude Code plugin with 76 agents, 39 commands, and 12 hooks t
 ## Quick Start
 
 ```bash
-# Install
+# Install (two commands)
+claude plugin marketplace add ShaheerKhawaja/ProductionOS
 claude plugin install productupgrade
 
 # Run on any codebase
@@ -206,20 +207,35 @@ Use `--profile budget` for ~40% savings.
 ## Installation
 
 ```bash
-# Via Claude Code marketplace
+# Recommended: via Claude Code plugin system
+claude plugin marketplace add ShaheerKhawaja/ProductionOS
 claude plugin install productupgrade
 
-# Manual
+# Alternative: manual git clone
 git clone https://github.com/ShaheerKhawaja/ProductionOS.git ~/.claude/plugins/marketplaces/productupgrade
-pos-init  # Initialize state directory
+```
+
+Restart Claude Code after install. Hooks, commands, and agents load on session start.
+
+### Update
+
+```bash
+claude plugin update productupgrade
+```
+
+### Uninstall
+
+```bash
+claude plugin uninstall productupgrade
 ```
 
 ## Validation
 
 ```bash
-bun test              # 589 tests, 0 failures
-bun run validate      # 75/76 agents valid
-bun run skill:check   # Plugin health score
+cd ~/.claude/plugins/marketplaces/productupgrade
+bun install && bun test   # 812 tests, 0 failures
+bun run validate          # 76/76 agents valid
+bun run skill:check       # Plugin health score
 ```
 
 ## What Makes This Different

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -56,17 +56,6 @@
   ],
   "PostToolUse": [
     {
-      "matcher": "Edit|Write|Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "python3 ~/.claude/skills/rlm/scripts/rlm_classifier.py",
-          "async": true,
-          "statusMessage": "RLM: Classifying output..."
-        }
-      ]
-    },
-    {
       "matcher": "Edit|Write",
       "hooks": [
         {

--- a/hooks/self-learn.sh
+++ b/hooks/self-learn.sh
@@ -81,7 +81,7 @@ case "$TOOL_NAME" in
 esac
 
 # Periodic pattern extraction
-ENTRY_COUNT=$(wc -l < "$SESSION_FILE" 2>/dev/null || echo "0")
+ENTRY_COUNT=$([ -f "$SESSION_FILE" ] && wc -l < "$SESSION_FILE" 2>/dev/null || echo "0")
 ENTRY_COUNT=$(echo "$ENTRY_COUNT" | tr -d ' ')
 
 # Single-session patterns (every 50 entries)


### PR DESCRIPTION
## Summary

- **Fix plugin name mismatch** — marketplace.json and plugin.json had `productionos` but settings reference `productupgrade`. Now consistent.
- **Fix README quickstart** — correct two-command install: `claude plugin marketplace add` + `claude plugin install productupgrade`
- **Remove external RLM dependency** from hooks.json PostToolUse (new users don't have ~/.claude/skills/rlm/)
- **Fix self-learn.sh crash** when session file doesn't exist yet (wc -l on missing file)

## Root Cause

The repo was renamed from `productupgrade` to `ProductionOS` but the internal plugin name was changed to `productionos`, breaking the `productupgrade@productupgrade` reference in Claude Code settings.

## Test plan

- [ ] `claude plugin marketplace add ShaheerKhawaja/ProductionOS` succeeds
- [ ] `claude plugin install productupgrade` finds and installs the plugin
- [ ] Session start hook fires without errors
- [ ] PostToolUse hooks don't crash (RLM removed)
- [ ] self-learn.sh handles fresh install with no session file

Generated with Claude Code