### PR TITLE
fix: remove broken agent references from 5 commands

### DIFF
--- a/.claude/commands/auto-swarm-nth.md
+++ b/.claude/commands/auto-swarm-nth.md
@@ -131,20 +131,21 @@ If any item uncovered OR any deliverable < 10: continue swarming.
 
 ---
 
-## RLM Auto-Detection (transparent)
+## Large File Handling (transparent)
 
 Before processing any file, check if it exceeds 50K characters.
-If yes, invoke the rlm-auto-activator agent to chunk and pre-process.
-This is transparent -- the command continues with pre-processed chunks.
+If yes, split into logical chunks (by class/function boundaries) and process each chunk separately.
+This is transparent -- the command continues with chunked results.
 
-Each swarm agent calls the rlm-auto-activator before processing any file in its work queue:
+Each swarm agent handles large files before processing its work queue:
 ```
 for file in work_queue:
-    result = rlm-auto-activator(file_path=file, session_id=f"swarm-nth-{wave}-{agent}")
-    if result.action == "passthrough":
+    if file_size(file) > 50_000:
+        chunks = split_by_declarations(file)
+        for chunk in chunks:
+            process_chunk(chunk)
+    else:
         process_file_directly(file)
-    elif result.action == "chunked":
-        process_via_rlm_pipeline(result.chunk_paths, query)
 ```
 
 ---

--- a/.claude/commands/auto-swarm.md
+++ b/.claude/commands/auto-swarm.md
@@ -138,19 +138,20 @@ Each agent explores a different code path or module:
 
 Convergence: full module map with dependency graph
 
-## RLM Auto-Detection (transparent)
+## Large File Handling (transparent)
 
 Before processing any file, check if it exceeds 50K characters.
-If yes, invoke the rlm-auto-activator agent to chunk and pre-process.
-This is transparent -- the command continues with pre-processed chunks.
+If yes, split into logical chunks (by class/function boundaries) and process each chunk separately.
+This is transparent -- the command continues with chunked results.
 
 ```
 for file in work_queue:
-    result = rlm-auto-activator(file_path=file, session_id=f"swarm-{agent_letter}")
-    if result.action == "passthrough":
+    if file_size(file) > 50_000:
+        chunks = split_by_declarations(file)
+        for chunk in chunks:
+            process_chunk(chunk)
+    else:
         process_file_directly(file)
-    elif result.action == "chunked":
-        process_via_rlm_pipeline(result.chunk_paths, query)
 ```
 
 ## Orchestration Protocol

--- a/.claude/commands/logic-mode.md
+++ b/.claude/commands/logic-mode.md
@@ -145,9 +145,9 @@ If the user wants to proceed to implementation:
 
 Logic Mode calls these agents/commands as needed:
 - `research-pipeline` — market and competitive research
-- `agentic-evaluator` — CLEAR framework assessment of the plan
+- `/agentic-eval` — CLEAR framework assessment of the plan
 - `decision-loop` — PIVOT/REFINE/PROCEED at Phase 3
-- `context-engineer` — build context for downstream agents
+- `/context-engineer` — build context for downstream agents
 - `/deep-research` — fill knowledge gaps
 - `/omni-plan` — handoff to execution
 

--- a/.claude/commands/omni-plan.md
+++ b/.claude/commands/omni-plan.md
@@ -37,13 +37,13 @@ You are the Omni-Plan orchestrator — ProductionOS's flagship mode. You chain e
 | balanced | Layers 1-8 (skip L9 distractor) | DOWN gate only (skip full panel) | Downgrade one level | Off |
 | budget | Layers 1-4 + L7 only | Single judge, no panel | quick | On (~41% token savings) |
 
-## RLM Auto-Detection (transparent)
+## Large File Handling (transparent)
 
 Before processing any file, check if it exceeds 50K characters.
-If yes, invoke the rlm-auto-activator agent to chunk and pre-process.
-This is transparent -- the command continues with pre-processed chunks.
+If yes, split into logical chunks (by class/function boundaries) and process each chunk separately.
+This is transparent -- the command continues with chunked results.
 
-During the 13-step pipeline, audit and review phases invoke rlm-auto-activator for:
+During the 13-step pipeline, large file handling applies to:
 - Large codebase files during analysis (Steps 1, 3-5)
 - Long documents during review (Steps 6-7)
 - Comprehensive test reports during evaluation (Steps 10-11)
@@ -139,7 +139,7 @@ Invoke the `research-pipeline` agent with the configured depth:
 **Confidence gate:** If research confidence < 80%, run additional search queries until satisfied. Do NOT proceed with unverified assumptions.
 
 ### Step 2: Context Engineering
-Invoke the `context-engineer` agent:
+Invoke the `/context-engineer` command:
 - Read all project docs (CLAUDE.md, README, architecture docs)
 - Check memory for past decisions (`/mem-search` for project history)
 - Build token budget plan for downstream agents
@@ -172,7 +172,7 @@ Invoke `/plan-design-review` (**External dependency** -- skip if unavailable, lo
 Output: `.productionos/REVIEW-DESIGN.md`
 
 ### Step 6: CLEAR Framework Evaluation
-Invoke the `agentic-evaluator` agent:
+Invoke the `/agentic-eval` command:
 - Evaluate the combined plan against the CLEAR v2.0 framework
 - 6-domain assessment (Foundations, Psychology, Segmentation, Maturity, Methodology, Validation)
 - 8 analysis dimensions (Comparative, Synthesis, Gap, Feasibility, Metrics, Evidence, Human-Centered, Decision Trees)

--- a/.claude/commands/production-upgrade.md
+++ b/.claude/commands/production-upgrade.md
@@ -57,16 +57,16 @@ After each agent completes, dispatch the self-evaluator agent (`agents/self-eval
 - Log all evaluations to `.productionos/self-eval/`
 - Feed scores into convergence tracking via `scripts/convergence.ts`
 
-## RLM Auto-Detection (transparent)
+## Large File Handling (transparent)
 
 Before processing any file, check if it exceeds 50K characters.
-If yes, invoke the rlm-auto-activator agent to chunk and pre-process.
-This is transparent -- the command continues with pre-processed chunks.
+If yes, split into logical chunks (by class/function boundaries) and process each chunk separately.
+This is transparent -- the command continues with chunked results.
 
-During audit phases, agents call rlm-auto-activator before reading source files:
-- Code reviewer calls it before analyzing large source files
-- Database auditor calls it before reading migration files
-- Dependency scanner calls it before parsing lock files
+During audit phases, agents handle large files by:
+- Code reviewer splits large source files by top-level declarations
+- Database auditor processes migration files individually
+- Dependency scanner reads lock file sections incrementally
 
 ## Pre-Execution Checks
 


### PR DESCRIPTION
## Summary

E2E audit of all 39 commands found 5 with broken agent references:

- **rlm-auto-activator** referenced in 4 commands but no agent file exists (external RLM dependency). Replaced with generic large-file chunking logic.
- **agentic-evaluator** referenced in 2 commands but should be `/agentic-eval` command. Fixed.
- **context-engineer** referenced as agent in 2 commands but should be `/context-engineer` command. Fixed.

## Files Changed

- `.claude/commands/production-upgrade.md`
- `.claude/commands/omni-plan.md`
- `.claude/commands/auto-swarm.md`
- `.claude/commands/auto-swarm-nth.md`
- `.claude/commands/logic-mode.md`

## Test plan

- [ ] All 39 commands reference only agents that exist in agents/
- [ ] No references to rlm-auto-activator remain
- [ ] /agentic-eval and /context-engineer correctly referenced as commands

Generated with Claude Code