### PR TITLE
fix: clean up remaining command issues from E2E audit

### DIFF
--- a/.claude/commands/autoloop.md
+++ b/.claude/commands/autoloop.md
@@ -16,10 +16,6 @@ The user provides:
 - **Target**: A file path, directory, or description of what to improve
 - **Goal**: What "good" looks like (optional -- defaults to "maximize quality score")
 
-## Step 0: Preamble
-
-Run the shared ProductionOS preamble (`templates/PREAMBLE.md`).
-
 ## Execution Protocol
 
 ### Step 1: Understand the Target

--- a/.claude/commands/productionos-help.md
+++ b/.claude/commands/productionos-help.md
@@ -7,9 +7,9 @@ description: "Show how to use ProductionOS — explains commands, recommended wo
 
 ## Getting Started
 
-ProductionOS v6.0 is your AI engineering team — 55 agents, 18 commands, 15+ hooks, 6 CLI tools, always present. Here's how to use it effectively.
+ProductionOS v1.0.0-beta.1 is your AI engineering team — 76 agents, 39 commands, 12 hooks, 6 CLI tools, 4 auto-activating skills. Here's how to use it effectively.
 
-## What's New in v6.0
+## What's New in v1.0
 
 - **Always-present hooks** — Security scan on auth/payment files, telemetry on every edit, review hints after 10+ changes, session handoff on exit
 - **CLI tools** — `pos-init`, `pos-config`, `pos-analytics`, `pos-update-check`
@@ -44,7 +44,7 @@ COMMAND                          WHEN TO USE
 /productionos-help               This guide
 ```
 
-### CLI Tools (v6.0)
+### CLI Tools
 
 ```
 pos-init                         Initialize ~/.productionos/ state

--- a/.claude/commands/productionos-update.md
+++ b/.claude/commands/productionos-update.md
@@ -57,7 +57,7 @@ If no git repo found, inform user:
 ```
 ProductionOS is not installed from git.
 To install the updatable version:
-  git clone https://github.com/ShaheerKhawaja/productupgrade.git ~/productupgrade
+  git clone https://github.com/ShaheerKhawaja/ProductionOS.git ~/productupgrade
   claude plugins add ~/productupgrade
 ```
 

--- a/.claude/commands/refine.md
+++ b/.claude/commands/refine.md
@@ -19,10 +19,6 @@ Before executing, run the shared ProductionOS preamble (`templates/PREAMBLE.md`)
 
 You are the RLM Refine orchestrator. You process pending signals from the RLM classifier, showing the user flagged outputs and applying L17 SelfRefine to improve them.
 
-## Step 0: Preamble
-
-Run the shared ProductionOS preamble (`templates/PREAMBLE.md`).
-
 ## Input
 - Mode: $ARGUMENTS.mode (default: interactive)
 - Max signals: $ARGUMENTS.max_signals (default: 10)


### PR DESCRIPTION
## Summary

Final cleanup from E2E audit of all 39 commands:

- **productionos-update.md**: Stale repo URL `productupgrade.git` → `ProductionOS.git`
- **autoloop.md**: Duplicate "Step 0: Preamble" section removed
- **refine.md**: Duplicate "Step 0: Preamble" section removed
- **productionos-help.md**: Version v6.0 → v1.0.0-beta.1, counts 55/18 → 76/39/12

## Test plan
- [ ] All 39 commands have no duplicate sections
- [ ] All repo URLs point to ShaheerKhawaja/ProductionOS
- [ ] Version references match VERSION file

Generated with Claude Code