### PR TITLE
fix: wire Ink UI + fix test failures (967/967 pass)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # ProductionOS 1.2.0-beta.1 — 10 Composites
 
-78-agent AI engineering OS with 10 composite entry points routing to 367 sub-skills. Project-aware context switching. Self-learning telemetry. Built for solo founders shipping multiple products.
+78-agent AI engineering OS with 41 commands, 10 composite entry points routing to 367 sub-skills. Project-aware context switching. Self-learning telemetry. Built for solo founders shipping multiple products.
 
 **The rule:** Never browse the full skill list. Use the 10 composites. Each routes to the best sub-skill for your context. See `~/.claude/skills/SKILL-ROUTER.md`.
 

--- a/bin/pos-analytics
+++ b/bin/pos-analytics
@@ -4,6 +4,15 @@ set -euo pipefail
 STATE_DIR="${PRODUCTIONOS_HOME:-$HOME/.productionos}"
 ANALYTICS="$STATE_DIR/analytics"
 
+# Try Ink dashboard first, fallback to plain text
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+INK_DASH="$PLUGIN_ROOT/scripts/ui/analytics-dashboard.tsx"
+# Only use Ink when stdout is a real TTY (not piped/captured by tests)
+if command -v bun >/dev/null 2>&1 && [ -f "$INK_DASH" ] && [ -t 1 ]; then
+  PRODUCTIONOS_HOME="$STATE_DIR" bun run "$INK_DASH" 2>/dev/null && exit 0
+fi
+
+# Fallback: plain text dashboard
 echo "ProductionOS Analytics"
 echo "━━━━━━━━━━━━━━━━━━━━━"
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -105,22 +105,43 @@ if [ ! -f "$STATE_DIR/.onboarded" ]; then
   echo "FIRST_RUN: true"
 fi
 
-cat << 'BANNER'
+# Try Ink banner first (styled React terminal UI), fallback to ASCII
+INK_BANNER="$PLUGIN_ROOT/scripts/ui/session-banner.tsx"
+VERSION=$(cat "$PLUGIN_ROOT/VERSION" 2>/dev/null || echo "1.2.0-beta.1")
+AGENT_COUNT=$(ls "$PLUGIN_ROOT/agents/"*.md 2>/dev/null | wc -l | tr -d ' ')
+CMD_COUNT=$(ls "$PLUGIN_ROOT/.claude/commands/"*.md 2>/dev/null | wc -l | tr -d ' ')
+HOOK_COUNT=$(ls "$PLUGIN_ROOT/hooks/"*.sh 2>/dev/null | wc -l | tr -d ' ')
+_LEARN_COUNT=0
+_LEARN_FILE="${STATE_DIR}/learnings/$(basename "${PROJECT_ROOT:-unknown}")/learnings.jsonl"
+[ -f "$_LEARN_FILE" ] && _LEARN_COUNT=$(wc -l < "$_LEARN_FILE" 2>/dev/null | tr -d ' ')
+
+# Only use Ink when stdout is a real TTY (not piped/captured by tests)
+if command -v bun >/dev/null 2>&1 && [ -f "$INK_BANNER" ] && [ -t 1 ]; then
+  bun run "$INK_BANNER" "$VERSION" "$AGENT_COUNT" "$CMD_COUNT" "$HOOK_COUNT" \
+    "$SESSIONS" "$AUTO_REVIEW" "$PROACTIVE" "${PROJECT_NAME:-}" \
+    "${DEVTOOLS_STATUS:-off}" "${DASHBOARD_METRICS:-}" "" \
+    "$_LEARN_COUNT" "${_PROFILE_SLUG:-}" "${FIRST_RUN:-}" 2>/dev/null || {
+    # Fallback if Ink fails
+    echo ""
+    echo "  ProductionOS $VERSION — 10 Composites"
+    echo "  Sessions: $SESSIONS | Learn: $PROACTIVE"
+    [ -n "${PROJECT_NAME:-}" ] && echo "  Project: $PROJECT_NAME"
+    echo ""
+  }
+else
+  # ASCII fallback (no bun or Ink not installed)
+  cat << BANNER
 
   ╔═══════════════════════════════════════════════════╗
-  ║  ProductionOS v2.0 — 10 Composites               ║
-  ╠═══════════════════════════════════════════════════╣
-  ║  /plan-ceo-review  /unified-review  /qa          ║
-  ║  /ship  /unified-debug  /unified-security        ║
-  ║  /deep-research  /unified-content  /retro        ║
-  ║  /auto-swarm                                     ║
+  ║  ProductionOS $VERSION — 10 Composites              ║
   ╠═══════════════════════════════════════════════════╣
 BANNER
-printf "  ║  Sessions: %-3s | Learn: %-4s                    ║\n" "$SESSIONS" "$PROACTIVE"
-if [ -n "$PROJECT_NAME" ]; then
-  printf "  ║  Project: %-40s ║\n" "$PROJECT_NAME"
+  printf "  ║  Sessions: %-3s | Learn: %-4s                    ║\n" "$SESSIONS" "$PROACTIVE"
+  if [ -n "${PROJECT_NAME:-}" ]; then
+    printf "  ║  Project: %-40s ║\n" "$PROJECT_NAME"
+  fi
+  echo "  ╚═══════════════════════════════════════════════════╝"
 fi
-echo "  ╚═══════════════════════════════════════════════════╝"
 echo "  Router: ~/.claude/skills/SKILL-ROUTER.md"
 
 # Show last retro action item if available

--- a/tests/e2e-hooks.test.ts
+++ b/tests/e2e-hooks.test.ts
@@ -99,7 +99,7 @@ describe("Hook Script E2E", () => {
       `PRODUCTIONOS_HOME=${TEST_STATE} bash ${join(HOOKS_DIR, "session-start.sh")}`
     );
     expect(result).toContain("ProductionOS");
-    expect(result).toContain("Production House");
+    expect(result).toContain("Composites");
   });
 
   test("pre-edit-security.sh allows non-sensitive files", () => {


### PR DESCRIPTION
## Summary
- Wire Ink terminal UI into session-start.sh and pos-analytics with TTY detection
- Fix 2 pre-existing test failures (command count + banner text)
- 967/967 tests pass, 0 failures

## Test plan
- [x] `bun test` — 967 pass, 0 fail
- [x] In terminal: Ink banner renders with styled output
- [x] In pipe: ASCII fallback renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)