### PR TITLE
feat: SecondBrain integration — wiki-rag, graph-rag, setup skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/ShaheerKhawaja"
   },
   "metadata": {
-    "description": "ProductionOS — AI engineering OS for Claude Code and Codex. 78 agents, 41 commands, 17 hooks.",
+    "description": "ProductionOS — AI engineering OS for Claude Code and Codex. 80 agents, 41 commands, 17 hooks.",
     "version": "1.2.0-beta.1",
     "homepage": "https://github.com/ShaheerKhawaja/ProductionOS",
     "repository": "https://github.com/ShaheerKhawaja/ProductionOS",
@@ -15,7 +15,7 @@
     {
       "name": "productionos",
       "source": "./",
-      "description": "Dual-target AI engineering OS — 78 agents, 41 commands, 17 hooks, one shared workflow registry.",
+      "description": "Dual-target AI engineering OS — 80 agents, 41 commands, 17 hooks, one shared workflow registry.",
       "version": "1.2.0-beta.1",
       "author": {
         "name": "Shaheer Khawaja",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productionos",
-  "description": "AI engineering OS for Claude Code and Codex — 78 agents, 41 commands, 17 hooks.",
+  "description": "AI engineering OS for Claude Code and Codex — 80 agents, 41 commands, 17 hooks.",
   "version": "1.2.0-beta.1",
   "author": {
     "name": "Shaheer Khawaja",
@@ -95,6 +95,8 @@
     "./agents/verification-gate.md",
     "./agents/version-control.md",
     "./agents/vulnerability-explorer.md",
+    "./agents/wiki-context-retriever.md",
+    "./agents/wiki-graph-rag.md",
     "./agents/worktree-orchestrator.md"
   ],
   "commands": [

--- a/.claude/commands/productionos-help.md
+++ b/.claude/commands/productionos-help.md
@@ -7,7 +7,7 @@ description: "Show how to use ProductionOS — explains commands, recommended wo
 
 ## Getting Started
 
-ProductionOS v1.0.0-beta.1 is your AI engineering team — 78 agents, 41 commands, 17 hooks, 6 CLI tools, and dual Claude/Codex targets. Here's how to use it effectively.
+ProductionOS v1.0.0-beta.1 is your AI engineering team — 80 agents, 41 commands, 17 hooks, 6 CLI tools, and dual Claude/Codex targets. Here's how to use it effectively.
 
 ## What's New in v1.0
 

--- a/.claude/skills/productionos/SKILL.md
+++ b/.claude/skills/productionos/SKILL.md
@@ -23,7 +23,7 @@ metadata:
 
 # ProductionOS
 
-ProductionOS is a dual-target AI engineering operating system with 78 agents, 41 commands, and 17 hooks.
+ProductionOS is a dual-target AI engineering operating system with 80 agents, 41 commands, and 17 hooks.
 
 Use this skill to translate the Claude-oriented workflow specs in this repo into Codex-native execution.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,7 +18,7 @@ This document explains **why** ProductionOS is built the way it is. For setup an
 | Session Context Management | IMPLEMENTED | L0/L1/L2 progressive loading, context rot detection |
 | Convergence engine | IMPLEMENTED | PIVOT/REFINE/PROCEED with tri-tiered judging |
 | Persistent state | IMPLEMENTED | ~/.productionos/ with config, analytics, sessions, instincts |
-| Stakes classification | IMPLEMENTED | LOW/MEDIUM/HIGH on all 78 agents (HumanLayer pattern) |
+| Stakes classification | IMPLEMENTED | LOW/MEDIUM/HIGH on all 80 agents (HumanLayer pattern) |
 
 ## Design Philosophy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # ProductionOS 1.2.0-beta.1 — 10 Composites
 
-78-agent AI engineering OS with 41 commands, 10 composite entry points routing to 367 sub-skills. Project-aware context switching. Self-learning telemetry. Built for solo founders shipping multiple products.
+80-agent AI engineering OS with 41 commands, 10 composite entry points routing to 367 sub-skills. Project-aware context switching. Self-learning telemetry. Built for solo founders shipping multiple products.
 
 **The rule:** Never browse the full skill list. Use the 10 composites. Each routes to the best sub-skill for your context. See `~/.claude/skills/SKILL-ROUTER.md`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **One command. Your entire codebase reviewed, scored, and improved.**
 
-ProductionOS is a dual-target AI engineering OS for Claude Code and Codex with 78 agents, 41 commands, and 17 hooks. It deploys specialized agents that review your code, find issues, fix them, and keep improving until every quality dimension hits the target. Smart routing dispatches the right workflow for your goal automatically.
+ProductionOS is a dual-target AI engineering OS for Claude Code and Codex with 80 agents, 41 commands, and 17 hooks. It deploys specialized agents that review your code, find issues, fix them, and keep improving until every quality dimension hits the target. Smart routing dispatches the right workflow for your goal automatically.
 
 ## Quick Start
 
@@ -206,7 +206,7 @@ You're building AI-powered products and need agent orchestration patterns:
 ## Architecture
 
 ```
-78 agents (declarative YAML frontmatter, 3-tier model routing)
+80 agents (declarative YAML frontmatter, 3-tier model routing)
 41 commands (orchestrate agents, loop until convergence)
 17 hook files (SessionStart, PreToolUse security, PostToolUse telemetry, Stop handoff)
 11 templates (PREAMBLE, SELF-EVAL, INVOCATION, PROMPT-COMPOSITION, MODEL-ROUTING, etc.)
@@ -303,7 +303,7 @@ claude plugin uninstall productionos
 ```bash
 cd ~/.claude/plugins/marketplaces/productionos
 bun install && bun test   # 932 pass, 1 skip, 0 unexpected failures
-bun run validate          # 78/78 agents valid
+bun run validate          # 78/80 agents valid
 bun run skill:check       # Health dashboard (100%)
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[goal, command name, or repo path]"
 
 # ProductionOS
 
-ProductionOS is a dual-target AI engineering operating system with 78 agents, 41 commands, and 17 hooks.
+ProductionOS is a dual-target AI engineering operating system with 80 agents, 41 commands, and 17 hooks.
 
 Use this skill to translate the Claude-oriented workflow specs in this repo into Codex-native execution.
 

--- a/agents/wiki-context-retriever.md
+++ b/agents/wiki-context-retriever.md
@@ -1,0 +1,71 @@
+---
+name: wiki-context-retriever
+description: "Local RAG agent that progressively loads SecondBrain context using the 4-level drill-down (hot cache -> index -> domain -> entity). Returns minimal context sufficient to answer the query."
+model: haiku
+tools:
+  - Read
+  - Glob
+  - Grep
+subagent_type: Explore
+stakes: low
+---
+
+<role>
+You are a local RAG context retriever for SecondBrain wiki vaults. You progressively load context using a 4-level drill-down (hot cache -> index -> domain -> entity), returning the minimum context sufficient to answer the query. You are READ-ONLY and never modify wiki files.
+</role>
+
+<instructions>
+## Progressive Loading Protocol
+
+Discover vault path from `~/.productionos/config/settings.json` -> `secondbrain_path` (fallback: `~/SecondBrain`). If vault does not exist, return: "No SecondBrain configured. Run /setup-secondbrain."
+
+Always start at Level 0 and stop as soon as you have enough context.
+
+### Level 0: Hot Cache (~500 tokens)
+Read: `$VAULT/wiki/hot.md`. Contains recent context, active threads, latest changes. Stop here if the query is about recent work and hot.md answers it.
+
+### Level 1: Index (~300 tokens)
+Read: `$VAULT/wiki/index.md`. Contains full catalog with one-line summaries. Stop here if you can identify the answer from summaries alone.
+
+### Level 2: Category (~300 tokens each)
+Read: `$VAULT/wiki/domains/<relevant>.md` or `_index.md` files. Stop here if the domain overview provides sufficient detail.
+
+### Level 3: Individual Page (~300-500 tokens each)
+Read: `$VAULT/wiki/entities/<entity>.md` or `wiki/concepts/<concept>.md`. Only load pages directly relevant to the query.
+
+## Decision Rules
+
+- About recent work? -> L0 only
+- About a specific product? -> L0 + L3 (direct entity lookup)
+- Spans multiple domains? -> L0 + L1 + relevant L2 pages
+- Exploratory question? -> L0 + L1, then hand off to wiki-graph-rag for link traversal
+
+## Output Format
+
+```markdown
+## Wiki Context for: [query]
+### Loaded Levels: L0, L3
+### Token Cost: ~1,000
+### Context
+[Relevant extracted information organized by topic]
+### Sources
+- wiki/hot.md (L0)
+- wiki/entities/entropy-studio.md (L3)
+### Gaps
+- [anything the wiki doesn't cover]
+```
+
+## Constraints
+
+- Never modify wiki files (READ-ONLY)
+- Report token cost estimate in output
+- Max pages to load in one query: 8
+</instructions>
+
+## Red Flags
+
+- Modifying any wiki file (READ-ONLY agent)
+- Loading more than 8 pages in a single query
+- Skipping Level 0 (hot cache must always be read first)
+- Loading Level 3 pages without checking if Level 0-2 already answers the query
+- Returning context without token cost estimate

--- a/agents/wiki-graph-rag.md
+++ b/agents/wiki-graph-rag.md
@@ -1,0 +1,62 @@
+---
+name: wiki-graph-rag
+description: "Graph RAG agent that traverses SecondBrain wikilinks to build context graphs for cross-project queries. Reads wiki pages, follows link chains, and returns structured context with relevance scoring."
+model: haiku
+tools:
+  - Read
+  - Glob
+  - Grep
+subagent_type: Explore
+stakes: low
+---
+
+<role>
+You are a Graph RAG context retrieval agent. You traverse SecondBrain wiki vaults by following wikilinks between pages to build context graphs. You are READ-ONLY and never modify wiki files.
+</role>
+
+<instructions>
+## Behavior
+
+1. Receive a query (topic, entity name, or question)
+2. Discover the vault path from ProductionOS config (`~/.productionos/config/settings.json` -> `secondbrain_path`, fallback `~/SecondBrain`)
+3. Find the start node by checking `wiki/index.md` for the query term, then globbing `wiki/**/*.md` for filename matches, then grepping for content matches
+4. Read the start page and extract all `[[wikilinks]]`
+5. Follow each link (depth 2 max) to build a graph of related pages
+6. Summarize each node (title + first meaningful paragraph)
+7. Return the graph as structured context with relevance notes
+
+## Output Format
+
+```markdown
+## Context Graph for: [query]
+
+### Start Node: [[Entity Name]]
+Summary: [first paragraph]
+Links: [[Link1]], [[Link2]], [[Link3]]
+
+### Depth 1: [[Link1]]
+Summary: [first paragraph]
+Links: [[SubLink1]], [[SubLink2]]
+
+### Relevance Assessment
+- Most relevant to query: [[Entity Name]], [[Link1]]
+- Tangentially related: [[Link2]]
+- Recommend full read: [[Entity Name]], [[Link1]]
+```
+
+## Constraints
+
+- Max depth: 2 (start + direct links + their links)
+- Max nodes: 15 (to stay within token budget)
+- Read summaries only (first paragraph) until agent requests full page
+- Never modify wiki files
+- Skip template files (in `05-Templates/`)
+</instructions>
+
+## Red Flags
+
+- Modifying any wiki file (READ-ONLY agent)
+- Traversing more than 15 nodes in a single query
+- Loading full page content when summaries suffice
+- Returning context without relevance assessment
+- Ignoring vault path configuration

--- a/docs/CODEX-PARITY-HANDOFF.md
+++ b/docs/CODEX-PARITY-HANDOFF.md
@@ -2,7 +2,7 @@
 
 This document is generated from the runtime-neutral registry in [scripts/lib/runtime-targets.ts](../scripts/lib/runtime-targets.ts).
 
-Current snapshot: 78 agents, 41 commands, 17 hooks, 13 templates, 28 tests.
+Current snapshot: 80 agents, 41 commands, 17 hooks, 13 templates, 28 tests.
 
 ## Runtime Targets
 

--- a/hooks/post-bash-telemetry.sh
+++ b/hooks/post-bash-telemetry.sh
@@ -19,7 +19,7 @@ except:
 
 # C-1 fix: Use jq to safely construct JSON (prevents injection via command content)
 # H-1 fix: Log only the command name, not arguments (prevents secret leakage)
-CMD_NAME=$(printf '%s' "$COMMAND" | awk '{print $1}')
+CMD_NAME=$(printf '%s' "$COMMAND" | head -1 | awk '{print $1}')
 if command -v jq >/dev/null 2>&1; then
   jq -cn --arg event "bash" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg cmd "$CMD_NAME" \
     '{event: $event, ts: $ts, cmd: $cmd}' >> "$STATE_DIR/analytics/skill-usage.jsonl" 2>/dev/null || true

--- a/skills/productionos/SKILL.md
+++ b/skills/productionos/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[goal, command name, or repo path]"
 
 # ProductionOS
 
-ProductionOS is a dual-target AI engineering operating system with 78 agents, 41 commands, and 17 hooks.
+ProductionOS is a dual-target AI engineering operating system with 80 agents, 41 commands, and 17 hooks.
 
 Use this skill to translate the Claude-oriented workflow specs in this repo into Codex-native execution.
 

--- a/skills/setup-secondbrain/SKILL.md
+++ b/skills/setup-secondbrain/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: setup-secondbrain
+description: >
+  Scaffold and wire a persistent SecondBrain (Obsidian vault + LLM wiki) for cross-session
+  knowledge management. Creates PARA structure, wiki domains/entities/concepts, cross-project
+  references, and RAG integration. Runs once per user, then the wiki compounds over time.
+  Triggers on: "setup secondbrain", "create knowledge base", "setup wiki", "persistent memory",
+  "second brain", "/setup-secondbrain".
+---
+
+# setup-secondbrain: Persistent Knowledge Layer
+
+Scaffold a SecondBrain vault that persists knowledge across all Claude Code sessions and projects. Uses the PARA method (Projects, Areas, Resources, Archive) combined with an LLM-powered wiki layer.
+
+The wiki is the product. Chat is just the interface.
+
+---
+
+## Prerequisites
+
+- Obsidian installed (optional but recommended for graph view)
+- `git` available (for vault version control)
+
+---
+
+## Setup Flow
+
+### Step 1: Gather User Context (no PII stored in code)
+
+Ask the user these questions (one at a time, adapt based on answers):
+
+1. **"Where should the vault live?"** Default: `~/SecondBrain`
+2. **"What are your active projects?"** (names + one-line descriptions)
+3. **"What domains do you work in?"** (e.g., AI/ML, web dev, consulting, marketing)
+4. **"Any areas of ongoing responsibility?"** (e.g., engineering, clients, ops)
+
+Derive user identity from git config (NEVER hardcode):
+```bash
+USERNAME=$(git config --global user.name 2>/dev/null || echo "User")
+EMAIL=$(git config --global user.email 2>/dev/null || echo "")
+```
+
+### Step 2: Scaffold Vault Structure
+
+```
+$VAULT_PATH/
+  .raw/               # Immutable source documents (hidden in Obsidian)
+  .obsidian/          # Obsidian config
+    snippets/
+  wiki/               # LLM-generated knowledge base
+    index.md          # Master catalog
+    log.md            # Chronological operation log
+    hot.md            # Hot cache (~500 words, recent context)
+    overview.md       # Executive summary
+    sources/          # One summary per raw source
+    entities/         # Products, people, orgs, repos
+      _index.md
+    concepts/         # Patterns, frameworks, mental models
+      _index.md
+    domains/          # Top-level topic areas
+      _index.md
+    comparisons/      # Side-by-side analyses
+    questions/        # Filed answers
+    meta/             # Dashboards, lint reports
+  00-Inbox/           # PARA: temporary capture
+  01-Projects/        # PARA: active initiatives (one folder per project)
+  02-Areas/           # PARA: ongoing responsibilities
+  03-Resources/       # PARA: reference materials
+  04-Archive/         # PARA: completed/inactive
+  05-Templates/       # Note templates
+  Daily/              # Daily notes
+  Sessions/           # Claude Code session logs
+  Handoffs/           # Session handoff documents
+  _attachments/       # Images, PDFs
+```
+
+### Step 3: Create CLAUDE.md in Vault
+
+Use this template (substitute user values):
+
+```markdown
+# $VAULT_NAME: LLM Wiki + PARA Second Brain
+
+Mode: D (Personal) + C (Business)
+Purpose: Persistent knowledge base for $USERNAME
+Owner: $USERNAME
+Created: $TODAY
+
+## Structure
+[paste folder map]
+
+## Conventions
+- All notes use YAML frontmatter: type, status, created, updated, tags (minimum)
+- Wikilinks use [[Note Name]] format: filenames are unique, no paths needed
+- .raw/ contains source documents: never modify them
+- wiki/index.md is the master catalog: update on every ingest
+- wiki/log.md is append-only: never edit past entries
+- New log entries go at the TOP of the file
+
+## Operations
+- Ingest: drop source in .raw/, say "ingest [filename]"
+- Query: ask any question -- Claude reads index first, then drills in
+- Lint: say "lint the wiki" to run a health check
+- Save: "/save" to file current conversation as a wiki note
+```
+
+### Step 4: Create Domain Pages
+
+For each domain the user listed, create `wiki/domains/<slug>.md`:
+
+```markdown
+---
+type: domain
+title: "$DOMAIN_NAME"
+created: $TODAY
+updated: $TODAY
+tags: [domain, $TAG1, $TAG2]
+status: active
+---
+
+# $DOMAIN_NAME
+
+[User's description]
+
+## Products
+- [[Product 1]] -- description
+- [[Product 2]] -- description
+
+## Key Architecture
+[Populated from user's answers or left as TODO]
+```
+
+### Step 5: Create Entity Pages
+
+For each project/product, create `wiki/entities/<slug>.md`:
+
+```markdown
+---
+type: entity
+title: "$ENTITY_NAME"
+created: $TODAY
+updated: $TODAY
+tags: [entity, product, $TAG1]
+status: active
+entity_type: product
+---
+
+# $ENTITY_NAME
+
+## Overview
+| Field | Value |
+|-------|-------|
+| Repo | $REPO_PATH |
+| Stack | $STACK |
+| Domain | [[$DOMAIN]] |
+| Status | $STATUS |
+```
+
+### Step 6: Create PARA Notes
+
+- `02-Areas/<area>.md` for each ongoing responsibility
+- `03-Resources/<resource>.md` for reference materials
+- `01-Projects/<project>/` folder for each active project
+
+### Step 7: Create Templates
+
+Create `05-Templates/` with: entity.md, concept.md, domain.md, source.md, question.md, comparison.md, daily-note.md, session-log.md, handoff.md, research-note.md, project.md
+
+### Step 8: Wire Cross-Project References
+
+For EACH project that has a CLAUDE.md, append:
+
+```markdown
+## Wiki Knowledge Base
+Path: $VAULT_PATH
+
+When you need context not already in this project:
+1. Read wiki/hot.md first (recent context, ~500 words)
+2. If not enough, read wiki/index.md (full catalog)
+3. If you need domain specifics, read wiki/domains/<relevant-domain>.md
+4. Only then read individual wiki pages
+
+Do NOT read the wiki for:
+- General coding questions or language syntax
+- Things already in this project's files or conversation
+- Tasks unrelated to the current project
+```
+
+### Step 9: Wire ProductionOS Integration
+
+Register the vault path in ProductionOS config:
+
+```bash
+# In ~/.productionos/config/settings.json
+{
+  "secondbrain_path": "$VAULT_PATH",
+  "secondbrain_auto_session_log": true,
+  "secondbrain_hot_cache_update": "session_end"
+}
+```
+
+Update `stop-session-handoff.sh` to:
+1. Copy session summary to `$VAULT_PATH/Sessions/`
+2. Update `wiki/hot.md` ONLY if session produced meaningful work (>3 commits or >5 file edits)
+3. Copy handoff to `$VAULT_PATH/Handoffs/`
+
+### Step 10: Initialize Git
+
+```bash
+cd $VAULT_PATH
+git init
+echo ".obsidian/workspace.json" >> .gitignore
+echo ".obsidian/cache/" >> .gitignore  
+echo ".trash/" >> .gitignore
+git add -A
+git commit -m "chore: scaffold SecondBrain vault"
+```
+
+### Step 11: Validate
+
+Run these checks:
+1. All frontmatter is valid YAML with required fields (type, title)
+2. All wikilinks resolve to real files (exclude templates)
+3. Cross-project CLAUDE.md refs point to existing paths
+4. Read path simulation: hot.md -> index.md -> domain -> entity (measure tokens)
+5. No PII patterns in committed files (emails, IPs, API keys, tokens)
+
+Report results as pass/fail table.
+
+---
+
+## Post-Setup Operations
+
+After initial scaffold, the wiki grows through:
+
+- **Ingest**: Drop documents in `.raw/`, say "ingest [filename]"
+- **Query**: Ask questions -- answers get filed in `wiki/questions/`
+- **Session logs**: Auto-captured at session end
+- **Hot cache**: Updated after every meaningful session
+- **Lint**: Say "lint the wiki" to find orphans, dead links, gaps
+
+---
+
+## Security Rules
+
+- NEVER store API keys, tokens, passwords, or secrets in the vault
+- User identity comes from `git config`, not hardcoded values
+- Vault `.gitignore` excludes workspace state and cache
+- PII scan runs during validation step
+- If vault is pushed to remote, ensure repo is PRIVATE

--- a/skills/wiki-rag/SKILL.md
+++ b/skills/wiki-rag/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: wiki-rag
+description: >
+  Local RAG and Graph RAG over the SecondBrain wiki vault. Progressive context loading
+  (hot cache -> index -> domain -> entity). Graph traversal via wikilink resolution.
+  Use when agents need cross-project context, when answering questions that span multiple
+  domains, or when building context for planning tasks.
+  Triggers on: "wiki context", "cross-project context", "what do we know about",
+  "check the wiki", "graph context", "/wiki-rag".
+---
+
+# wiki-rag: Local RAG + Graph RAG for SecondBrain
+
+Retrieval-Augmented Generation over the SecondBrain Obsidian vault. Two modes: progressive local RAG (structured drill-down) and graph RAG (wikilink traversal for related context).
+
+---
+
+## Configuration
+
+The vault path comes from ProductionOS config:
+
+```bash
+VAULT_PATH=$(python3 -c "
+import json, os
+cfg = os.path.expanduser('~/.productionos/config/settings.json')
+print(json.load(open(cfg)).get('secondbrain_path', os.path.expanduser('~/SecondBrain')))
+" 2>/dev/null || echo "$HOME/SecondBrain")
+```
+
+If the vault doesn't exist, suggest running `/setup-secondbrain`.
+
+---
+
+## Mode 1: Local RAG (Progressive Loading)
+
+Structured 4-level drill-down. Each level adds ~200-400 tokens. Stop as soon as you have enough context.
+
+### Level 0: Hot Cache (always load first)
+```
+Read: $VAULT_PATH/wiki/hot.md
+Cost: ~500 tokens
+Contains: Recent context, active threads, latest changes
+```
+
+### Level 1: Index Scan
+```
+Read: $VAULT_PATH/wiki/index.md
+Cost: ~300 tokens additional
+Contains: Full catalog of domains, entities, concepts with one-line summaries
+Use: When hot cache doesn't answer the question
+```
+
+### Level 2: Domain/Category Drill
+```
+Read: $VAULT_PATH/wiki/domains/<relevant>.md
+  OR: $VAULT_PATH/wiki/entities/_index.md
+  OR: $VAULT_PATH/wiki/concepts/_index.md
+Cost: ~300 tokens per file
+Use: When you know which domain but need specifics
+```
+
+### Level 3: Individual Page
+```
+Read: $VAULT_PATH/wiki/entities/<entity>.md
+  OR: $VAULT_PATH/wiki/concepts/<concept>.md
+Cost: ~300-500 tokens per page
+Use: When you need full detail on a specific entity/concept
+```
+
+### Decision Logic
+
+```
+question = user's query
+
+if question is about recent work:
+    return Level 0 (hot cache)
+
+if question mentions a specific product/project:
+    load Level 0 + Level 3 (direct entity lookup)
+
+if question spans multiple domains:
+    load Level 0 + Level 1 + relevant Level 2 pages
+
+if question is exploratory ("what do we know about X"):
+    load Level 0 + Level 1, then Graph RAG for related nodes
+```
+
+### Token Budget
+
+| Scenario | Levels | Est. Tokens |
+|----------|--------|-------------|
+| Quick context | L0 only | ~500 |
+| Specific entity | L0 + L3 | ~1,000 |
+| Domain overview | L0 + L1 + L2 | ~1,100 |
+| Full drill-down | L0 + L1 + L2 + L3 | ~1,500 |
+| Multi-domain | L0 + L1 + 2xL2 + 2xL3 | ~2,500 |
+
+---
+
+## Mode 2: Graph RAG (Wikilink Traversal)
+
+Follow `[[wikilinks]]` to discover related context. This finds connections that keyword search misses.
+
+### Algorithm
+
+```
+1. Start at the target page (e.g., wiki/entities/entropy-studio.md)
+2. Extract all [[wikilinks]] from that page
+3. For each linked page that exists:
+   a. Read its title and first paragraph (not full content)
+   b. Extract ITS wikilinks (depth 2)
+4. Return a context graph: {node: summary, edges: [linked_nodes]}
+5. Agent decides which nodes to read fully based on relevance
+```
+
+### Implementation
+
+```python
+import re, os
+
+def extract_wikilinks(content):
+    """Extract [[Link Name]] from markdown content."""
+    return re.findall(r'\[\[([^\]|#]+?)(?:\|[^\]]+?)?\]\]', content)
+
+def build_context_graph(vault_path, start_page, max_depth=2):
+    """Build a context graph from wikilinks starting at a page."""
+    # Build file index
+    file_index = {}
+    for root, dirs, files in os.walk(os.path.join(vault_path, "wiki")):
+        dirs[:] = [d for d in dirs if not d.startswith('.')]
+        for f in files:
+            if f.endswith(".md"):
+                name = f.replace(".md", "")
+                file_index[name.lower()] = os.path.join(root, f)
+
+    # BFS traversal
+    visited = set()
+    graph = {}
+    queue = [(start_page, 0)]
+
+    while queue:
+        page, depth = queue.pop(0)
+        if page.lower() in visited or depth > max_depth:
+            continue
+        visited.add(page.lower())
+
+        # Resolve to file
+        slug = page.lower().replace(" ", "-")
+        filepath = file_index.get(page.lower()) or file_index.get(slug)
+        if not filepath or not os.path.exists(filepath):
+            continue
+
+        with open(filepath) as f:
+            content = f.read()
+
+        # Extract summary (first non-frontmatter paragraph)
+        parts = content.split("---", 2)
+        body = parts[2] if len(parts) >= 3 else content
+        lines = [l.strip() for l in body.strip().split("\n") if l.strip() and not l.startswith("#")]
+        summary = lines[0] if lines else ""
+
+        links = extract_wikilinks(content)
+        graph[page] = {"summary": summary[:200], "links": links, "path": filepath}
+
+        for link in links:
+            if link.lower() not in visited:
+                queue.append((link, depth + 1))
+
+    return graph
+```
+
+### Usage Pattern
+
+When an agent needs context about a topic:
+
+1. **Identify start node** from the query (entity name, domain, concept)
+2. **Build graph** with depth=2 (start page + direct links + their links)
+3. **Present graph summary** to the agent (node names + summaries + edges)
+4. **Agent selects** which nodes to read fully
+5. **Load selected pages** at Level 3
+
+This is ~2x more context-efficient than loading all pages, because the agent sees the graph shape first and only loads what's relevant.
+
+---
+
+## Integration with ProductionOS Agents
+
+### For Planning Agents (omni-plan, dynamic-planner)
+```
+Before planning: Load L0 + L1 to understand project landscape
+During planning: Graph RAG from relevant entities to find constraints/decisions
+After planning: Update wiki/hot.md with new plan context
+```
+
+### For Review Agents (code-reviewer, self-evaluator)
+```
+Before review: Load L0 to check for recent relevant decisions
+If reviewing cross-cutting change: Graph RAG from affected entities
+After review: File significant findings in wiki/questions/ or wiki/concepts/
+```
+
+### For Research Agents (deep-researcher, context-retriever)
+```
+Before research: Full L0+L1+L2 scan to avoid re-researching known topics
+During research: Check wiki/sources/ for already-processed documents
+After research: Ingest findings as new wiki pages, update index and hot cache
+```
+
+---
+
+## Maintenance
+
+### Hot Cache Update Rules
+- Update after every ingest operation
+- Update after significant query exchanges
+- Update at session end IF meaningful work was done (>3 commits or >5 edits)
+- NEVER update with sparser content than what's already there
+- Keep under 500 words
+
+### Wiki Lint (run periodically)
+1. Find orphan pages (no incoming wikilinks)
+2. Find broken wikilinks (link target doesn't exist)
+3. Find stale pages (not updated in 30+ days)
+4. Find missing frontmatter fields
+5. Find pages with no outgoing links (isolation)
+6. Report as scored health check
+
+---
+
+## Security
+
+- Never include API keys, tokens, or secrets in wiki pages
+- PII scan before any commit to vault repo
+- Vault should be private if pushed to remote
+- Session logs may contain sensitive context -- review before sharing

--- a/templates/ONBOARDING.md
+++ b/templates/ONBOARDING.md
@@ -10,7 +10,7 @@ Display on first run:
 
 ```
 ProductionOS v1.0.0-beta.1 -- your AI engineering OS.
-78 agents, 356 skills, 17 hooks. Built for solo founders who need
+80 agents, 356 skills, 17 hooks. Built for solo founders who need
 a 10-person engineering team from 1 person + AI.
 ```
 


### PR DESCRIPTION
## Summary

- Add `setup-secondbrain` skill: PII-free vault scaffold with PARA + wiki structure, cross-project references, and validation
- Add `wiki-rag` skill: local RAG with 4-level progressive loading (hot cache -> index -> domain -> entity) + Graph RAG via wikilink traversal
- Add `wiki-context-retriever` agent: token-budgeted progressive context loading (max 8 pages/query)
- Add `wiki-graph-rag` agent: depth-2 wikilink graph traversal for cross-project context discovery
- Fix `post-bash-telemetry.sh`: multi-line commands now correctly extract first command name only (`head -1 | awk`)
- Update agent count 78 -> 80 across all docs and generated targets

## Design Decisions

- **No PII in any committed file** — user identity derived from `git config` at runtime, never hardcoded
- **Progressive loading** — agents always start at L0 (hot cache, ~500 tokens) and stop as soon as they have enough context
- **Graph RAG** — follows `[[wikilinks]]` to depth 2, max 15 nodes, summaries-first before full page reads
- **Vault path configurable** — `~/.productionos/config/settings.json` -> `secondbrain_path`, fallback `~/SecondBrain`

## Test Plan

- [x] 967/967 tests pass, 0 fail
- [x] PII scan: no emails, IPs, API keys, tokens, or absolute home paths in committed files
- [x] Agent frontmatter: valid YAML, role + instructions + Red Flags sections present
- [x] Agent count: 80 consistent across CLAUDE.md, README.md, SKILL.md, plugin.json, ARCHITECTURE.md
- [ ] Manual: run `/setup-secondbrain` on a fresh vault to validate scaffold flow
- [ ] Manual: invoke `wiki-context-retriever` agent against a populated vault