### PR TITLE
feat(skills): upgrade 10 infrastructure skills to dense runbooks (v1.3.0 Iter 2)

### DIFF
--- a/scripts/lib/runtime-targets.ts
+++ b/scripts/lib/runtime-targets.ts
@@ -682,6 +682,14 @@ const HAND_CRAFTED_SKILLS = new Set([
   "debug",
   "brainstorming",
   "document-release",
+  "devtools",
+  "productionos-help",
+  "productionos-pause",
+  "productionos-resume",
+  "productionos-stats",
+  "productionos-update",
+  "autoloop",
+  "qa-only",
 ]);
 
 export function getGeneratedTargetFiles(): GeneratedTargetFile[] {

--- a/skills/autoloop/SKILL.md
+++ b/skills/autoloop/SKILL.md
@@ -6,49 +6,141 @@ argument-hint: "[repo path, target, or task context]"
 
 # autoloop
 
-## Overview
-
-This is the Codex-native workflow wrapper for [.claude/commands/autoloop.md](../../.claude/commands/autoloop.md).
-
-Use it when the user wants this exact ProductionOS workflow, not just the umbrella `productionos` router.
-
-## Source of Truth
-
-1. Read the source command spec at [.claude/commands/autoloop.md](../../.claude/commands/autoloop.md).
-2. Use [CODEX-PARITY-HANDOFF.md](../../docs/CODEX-PARITY-HANDOFF.md) to confirm runtime support and parity expectations.
-3. Preserve the source workflow's guardrails, scope, artifacts, and verification intent.
-4. Translate Claude-only slash-command and hook semantics into Codex-native execution instead of copying them literally.
-
-## Codex Behavior
-
-- Summary: Autonomous recursive improvement loop for a single target. Runs gap analysis, recursive refinement, evaluation, and convergence checks until the target reaches quality threshold or converges.
-- Use the source command as the behavioral spec, then execute the same intent with Codex-native tools and constraints.
+Autonomous recursive improvement loop for a single target. Runs gap analysis, recursive refinement, evaluation, and convergence checks until the target reaches quality threshold or converges.
 
 ## Inputs
 
-- No explicit arguments. Use repo path, target, or task context as needed.
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `target` | path or context | cwd | What to operate on |
 
-## Execution Outline
+# /autoloop — Autonomous Recursive Improvement
 
-1. Preamble
+## Step 0: Preamble
+Before executing, run the shared ProductionOS preamble (`templates/PREAMBLE.md`).
 
-## Agents And Assets
+You are running the `/autoloop` command. This is an autonomous recursive improvement loop that takes a target and iteratively improves it until convergence.
 
-- Agents: no explicit agent references in the source command.
-- Templates: `PREAMBLE.md`
-- Artifacts: `.productionos/recursive/metrics/`, `.productionos/recursive/recursion-state.json`, `.productionos/recursive/reference-corpus/`
+## Input
 
-## Workflow
+The user provides:
+- **Target**: A file path, directory, or description of what to improve
+- **Goal**: What "good" looks like (optional -- defaults to "maximize quality score")
 
-1. Load only the agents, templates, prompts, and docs referenced by the source command.
-2. Execute the workflow intent with Codex-native tools.
-3. If the source command implies parallel agent work, only delegate when the user explicitly wants that overhead.
-4. Verify with the smallest relevant checks before concluding.
-5. Summarize what changed, what was verified, and what still needs human approval.
+## Execution Protocol
+
+### Step 1: Understand the Target
+1. If target is a file path: Read it and assess current state
+2. If target is a directory: Scan for key files and assess overall quality
+3. If target is a description: Identify what needs to be created or improved
+
+### Step 2: Gap Analysis
+1. Score current state using the ProductionOS rubric and convergence heuristics already present in this repo
+2. Scan `~/repos/` for reference implementations (per CLAUDE.md Auto-Enrichment Protocol)
+3. Check `~/.productionos/recursive/reference-corpus/` for similar high-quality outputs
+4. Identify specific gaps between current state and goal
+
+### Step 3: Initialize Recursion
+1. Create session state at `~/.productionos/recursive/recursion-state.json`:
+   ```json
+   {
+     "session_id": "<generated>",
+     "target": "<target>",
+     "goal": "<goal>",
+     "layer": "L17",
+     "current_iteration": 0,
+     "max_iterations": 10,
+     "best_iteration": 0,
+     "best_score": 0.0,
+     "scores": [],
+     "convergence_verdict": "CONTINUE",
+     "status": "running"
+   }
+   ```
+2. Select the appropriate layer:
+   - Complex decomposable task -> L16 RecDecomp
+   - Quality improvement (default) -> L17 SelfRefine
+   - Context too large -> L18 RecSumm
+   - Security/factual claims -> L19 RecVerify
+   - Plan execution -> L20 PEER
+
+### Step 4: Iteration Loop (max 10)
+
+For each iteration:
+
+1. **Score**: Run confidence scorer on current output
+2. **Record**: Add score to convergence monitor
+3. **Check Convergence**: Run all 5 algorithms from `convergence.py`:
+   - Score delta tracking (stalled if < 0.1 for 2+ iterations)
+   - Spectral contraction (converged if cosine > 0.95)
+   - Diminishing returns (stalled if DR ratio < 0.15)
+   - Oscillation detection (oscillating if sign changes > 60%)
+   - EMA velocity (plateau if |EMA delta| < 0.05)
+4. **If STOP**: Return best iteration output
+5. **If CONTINUE**: Apply refinement via the selected layer
+6. **Quality Gate**: Check for monotonic improvement and stop if the loop regresses materially
+7. **Log**: Write metrics to `~/.productionos/recursive/metrics/`
+
+### Step 5: Completion
+1. Return the output from the best-scoring iteration
+2. Show convergence trajectory (ASCII visualization)
+3. Report: iterations completed, final score, convergence reason
+4. Save final state to recursion-state.json
+
+## Output Format
+
+```
+AUTOLOOP COMPLETE
+Target: <target>
+Goal: <goal>
+Iterations: <n> / <max>
+Best Score: <score> (iteration <i>)
+Convergence: <verdict> — <reason>
+
+Trajectory:
+  i=0  |***           | 4.20
+  i=1  |*********     | 6.50 (+2.30)
+  i=2  |***********   | 7.20 (+0.70)
+  i=3  |************  | 7.30 (+0.10) <- converged
+
+Applied: <output from best iteration>
+```
+
+## Constraints
+
+- Max 10 iterations per autoloop invocation
+- Configurable depth per iteration (default: 1)
+- Always check token budget before each iteration
+- Never modify Phase 1 or Phase 2 RLM scripts
+- Log everything to metrics for PromptEvo batch analysis
+- Use `rlm-recursive-orchestrator` agent for depth management when needed
+
+## Integration
+
+This command integrates all Phase 1-3 RLM components:
+- `confidence_scorer.py` — scoring each iteration
+- `quality_gate.py` — monotonic improvement enforcement
+- `convergence.py` — 5-algorithm convergence detection
+- `instinct_scorer.py` — weight adjustment from learned patterns
+- `embedding_corpus.py` — reference comparison
+- `prompt_evolution.py` — active prompt selection per layer
+- `tier2_live_eval.py` — evaluation framework
+- `rlm_classifier.py` — budget circuit breaker
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| No target provided | Ask for clarification with examples |
+| Target not found | Search for alternatives, suggest closest match |
+| Missing dependencies | Report what is needed and how to install |
+| Permission denied | Check file permissions, suggest fix |
+| State file corrupted | Reset to defaults, report what was lost |
 
 ## Guardrails
 
-- Do not claim that Claude-only marketplace, hook, or slash-command behavior runs directly in Codex.
-- Keep the scope faithful to the source command rather than broadening into a generic repo audit.
-- Prefer concrete outputs and validation over describing the workflow abstractly.
-- Preserve the scope and stop conditions from the source command rather than broadening into a generic repo audit.
+1. Do not silently change scope or expand beyond the user request.
+2. Prefer concrete outputs and verification over abstract descriptions.
+3. Keep scope faithful to the user intent.
+4. Preserve existing workflow guardrails and stop conditions.
+5. Verify results before concluding.

--- a/skills/devtools/SKILL.md
+++ b/skills/devtools/SKILL.md
@@ -6,49 +6,112 @@ argument-hint: "[repo path, target, or task context]"
 
 # devtools
 
-## Overview
-
-This is the Codex-native workflow wrapper for [.claude/commands/devtools.md](../../.claude/commands/devtools.md).
-
-Use it when the user wants this exact ProductionOS workflow, not just the umbrella `productionos` router.
-
-## Source of Truth
-
-1. Read the source command spec at [.claude/commands/devtools.md](../../.claude/commands/devtools.md).
-2. Use [CODEX-PARITY-HANDOFF.md](../../docs/CODEX-PARITY-HANDOFF.md) to confirm runtime support and parity expectations.
-3. Preserve the source workflow's guardrails, scope, artifacts, and verification intent.
-4. Translate Claude-only slash-command and hook semantics into Codex-native execution instead of copying them literally.
-
-## Codex Behavior
-
-- Summary: ProductionOS Mission Control — launch Claude DevTools, show session dashboard with eval convergence, agent dispatches, cost tracking, and hot file intelligence.
-- Use the source command as the behavioral spec, then execute the same intent with Codex-native tools and constraints.
+ProductionOS Mission Control — launch Claude DevTools, show session dashboard with eval convergence, agent dispatches, cost tracking, and hot file intelligence.
 
 ## Inputs
 
-- `action` — Action: 'launch' (default), 'status', 'focus', 'quit' Default: `launch` Optional.
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | string | launch | Action: 'launch' (default), 'status', 'focus', 'quit' |
 
-## Execution Outline
+# ProductionOS DevTools — Mission Control
 
-1. Preamble
+## Step 0: Preamble
 
-## Agents And Assets
+Before executing, run the shared ProductionOS preamble (`templates/PREAMBLE.md`) to confirm the active install root and session context.
 
-- Agents: no explicit agent references in the source command.
-- Templates: `PREAMBLE.md`
-- Artifacts: no explicit `.productionos/` artifacts called out in the source command.
+Execute the requested action for Claude DevTools within the ProductionOS ecosystem.
 
-## Workflow
+## Action: $ARGUMENTS.action
 
-1. Load only the agents, templates, prompts, and docs referenced by the source command.
-2. Execute the workflow intent with Codex-native tools.
-3. If the source command implies parallel agent work, only delegate when the user explicitly wants that overhead.
-4. Verify with the smallest relevant checks before concluding.
-5. Summarize what changed, what was verified, and what still needs human approval.
+### Step 1: Check DevTools installation and status
+
+```bash
+DEVTOOLS_APP="/Applications/claude-devtools.app"
+if [ ! -d "$DEVTOOLS_APP" ]; then
+  echo "DEVTOOLS_NOT_INSTALLED"
+  echo "Install with: brew install --cask claude-devtools"
+else
+  DEVTOOLS_PID=$(pgrep -f "claude-devtools" 2>/dev/null | head -1)
+  if [ -n "$DEVTOOLS_PID" ]; then
+    echo "DEVTOOLS_RUNNING (PID: $DEVTOOLS_PID)"
+  else
+    echo "DEVTOOLS_STOPPED"
+  fi
+fi
+```
+
+If not installed, tell the user to run `brew install --cask claude-devtools` and stop.
+
+### Step 2: Execute action
+
+**launch** (default):
+1. If DevTools is NOT running, launch it:
+   ```bash
+   open /Applications/claude-devtools.app
+   ```
+2. If already running, bring to foreground:
+   ```bash
+   osascript -e 'tell application "claude-devtools" to activate'
+   ```
+3. Then show the full dashboard (Step 3)
+
+**status**:
+1. Run the dashboard script for the full report:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/productionos}/hooks/devtools-dashboard.py" --full
+   ```
+2. Display the output to the user as-is (it's already formatted)
+
+**focus**:
+1. Bring DevTools window to foreground:
+   ```bash
+   osascript -e 'tell application "claude-devtools" to activate'
+   ```
+
+**quit**:
+1. Gracefully quit DevTools:
+   ```bash
+   osascript -e 'tell application "claude-devtools" to quit'
+   ```
+
+### Step 3: Full Dashboard (runs on launch and status)
+
+Run the dashboard script:
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/productionos}/hooks/devtools-dashboard.py" --full
+```
+
+This shows:
+- Session metrics (edits, agents, security events)
+- Cost tracking (session delta, all-time total)
+- Eval convergence (latest score, sparkline trend, data points)
+- Agent dispatch breakdown by type
+- Hot files (cross-session churn with bar charts)
+- Event breakdown
+
+### Step 4: Report to user
+
+After executing the action, provide a concise summary:
+- For **launch**: Show the full dashboard output, then "DevTools launched"
+- For **status**: Show the full dashboard output only
+- For **focus**: "DevTools brought to foreground"
+- For **quit**: "DevTools closed"
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| No target provided | Ask for clarification with examples |
+| Target not found | Search for alternatives, suggest closest match |
+| Missing dependencies | Report what is needed and how to install |
+| Permission denied | Check file permissions, suggest fix |
+| State file corrupted | Reset to defaults, report what was lost |
 
 ## Guardrails
 
-- Do not claim that Claude-only marketplace, hook, or slash-command behavior runs directly in Codex.
-- Keep the scope faithful to the source command rather than broadening into a generic repo audit.
-- Prefer concrete outputs and validation over describing the workflow abstractly.
-- Preserve the scope and stop conditions from the source command rather than broadening into a generic repo audit.
+1. Do not silently change scope or expand beyond the user request.
+2. Prefer concrete outputs and verification over abstract descriptions.
+3. Keep scope faithful to the user intent.
+4. Preserve existing workflow guardrails and stop conditions.
+5. Verify results before concluding.

--- a/skills/interface-craft/SKILL.md
+++ b/skills/interface-craft/SKILL.md
@@ -12,6 +12,12 @@ A toolkit for building polished, animated interfaces. Write animations you can r
 
 ---
 
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `target` | path or context | cwd | What to operate on |
+
 ## Skills
 
 | Skill | When to Use | Invoke |
@@ -77,3 +83,10 @@ When the user invokes `/interface-craft`:
 3. **Data-driven** — Repeated elements use arrays and `.map()`, not copy-pasted blocks
 4. **Stage-driven** — A single integer state drives the entire sequence; no scattered boolean flags
 5. **Spring-first** — Prefer spring physics over duration-based easing for natural motion
+
+## Guardrails
+
+1. Do not silently change scope.
+2. Prefer concrete outputs over abstract descriptions.
+3. Keep scope faithful to user intent.
+4. Verify results before concluding.

--- a/skills/productionos-help/SKILL.md
+++ b/skills/productionos-help/SKILL.md
@@ -6,49 +6,187 @@ argument-hint: "[repo path, target, or task context]"
 
 # productionos-help
 
-## Overview
-
-This is the Codex-native workflow wrapper for [.claude/commands/productionos-help.md](../../.claude/commands/productionos-help.md).
-
-Use it when the user wants this exact ProductionOS workflow, not just the umbrella `productionos` router.
-
-## Source of Truth
-
-1. Read the source command spec at [.claude/commands/productionos-help.md](../../.claude/commands/productionos-help.md).
-2. Use [CODEX-PARITY-HANDOFF.md](../../docs/CODEX-PARITY-HANDOFF.md) to confirm runtime support and parity expectations.
-3. Preserve the source workflow's guardrails, scope, artifacts, and verification intent.
-4. Translate Claude-only slash-command and hook semantics into Codex-native execution instead of copying them literally.
-
-## Codex Behavior
-
-- Summary: Show how to use ProductionOS — explains commands, recommended workflows, best flows to run, and usage guidelines.
-- Use the source command as the behavioral spec, then execute the same intent with Codex-native tools and constraints.
+Show how to use ProductionOS — explains commands, recommended workflows, best flows to run, and usage guidelines.
 
 ## Inputs
 
-- No explicit arguments. Use repo path, target, or task context as needed.
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `target` | path or context | cwd | What to operate on |
 
-## Execution Outline
+# ProductionOS — Usage Guide
 
-1. Preamble
+## Getting Started
 
-## Agents And Assets
+ProductionOS v1.0.0-beta.1 is your AI engineering team — 80 agents, 41 commands, 17 hooks, 6 CLI tools, and dual Claude/Codex targets. Here's how to use it effectively.
 
-- Agents: no explicit agent references in the source command.
-- Templates: `PREAMBLE.md`
-- Artifacts: `.productionos/RESEARCH-`
+## What's New in v1.0
 
-## Workflow
+- **Always-present hooks** — Security scan on auth/payment files, telemetry on every edit, review hints after 10+ changes, session handoff on exit
+- **CLI tools** — `pos-init`, `pos-config`, `pos-analytics`, `pos-update-check`
+- **Auto-activating skills** — Skills trigger based on file patterns (auth → security-scan, .tsx → frontend-audit)
+- **Continuous learning** — Extracts patterns from sessions, builds instincts with confidence scoring
+- **`/frontend-upgrade`** — CEO vision + parallel swarm for frontend transformation
 
-1. Load only the agents, templates, prompts, and docs referenced by the source command.
-2. Execute the workflow intent with Codex-native tools.
-3. If the source command implies parallel agent work, only delegate when the user explicitly wants that overhead.
-4. Verify with the smallest relevant checks before concluding.
-5. Summarize what changed, what was verified, and what still needs human approval.
+## Step 0: Preamble
+
+All ProductionOS commands run the shared preamble (`templates/PREAMBLE.md`) before execution. This includes environment check, prior work discovery, agent resolution, cost estimation, and prompt injection defense.
+
+## Quick Reference
+
+```
+COMMAND                          WHEN TO USE
+/production-upgrade              Audit and improve any codebase (start here)
+/omni-plan                       Full 13-step pipeline for major work
+/omni-plan-nth                   Recursive perfection — loops until 10/10
+/auto-swarm "task"               Throw agents at any task in parallel
+/auto-swarm-nth "task"           Recursive swarm until 100% coverage
+/max-research "topic"            500-1000 agents — exhaustive research (nuclear)
+/deep-research "topic"           Research anything before building
+/agentic-eval                    Evaluate quality with CLEAR framework
+/security-audit                  7-domain security deep-dive
+/context-engineer                Build token-optimized context packages
+/logic-mode "idea"               Validate a business idea
+/learn-mode "topic"              Interactive code tutor
+/productionos-pause              Save pipeline state for later
+/productionos-resume             Resume from checkpoint
+/productionos-update             Update to latest version
+/frontend-upgrade                CEO-enriched frontend transformation
+/productionos-help               This guide
+```
+
+### CLI Tools
+
+```
+pos-init                         Initialize ~/.productionos/ state
+pos-config list|get|set          Manage settings
+pos-analytics                    Usage dashboard
+pos-update-check                 Version check
+```
+
+## Recommended Workflows
+
+### Flow 1: "I want to improve an existing codebase"
+```
+Step 1: /production-upgrade              Run a baseline audit
+Step 2: Review the findings in .productionos/
+Step 3: /omni-plan-nth                   Recursive improvement until 10/10
+```
+This is the most common flow. `/production-upgrade` gives you a quick health score, then `/omni-plan-nth` iterates until every dimension is perfect.
+
+### Flow 2: "I'm starting a new project/feature"
+```
+Step 1: /logic-mode "describe your idea"     Validate the concept
+Step 2: /deep-research "relevant domain"     Research best practices
+Step 3: /omni-plan --focus=architecture      Plan the architecture
+Step 4: /auto-swarm-nth "build the feature"  Execute with parallel agents
+Step 5: /production-upgrade validate         Final validation pass
+```
+
+### Flow 3: "I need to research something first"
+```
+Step 1: /deep-research "your topic"          Deep 8-phase research
+Step 2: /omni-plan                           Plan using research findings
+```
+The research artifacts in `.productionos/RESEARCH-*.md` are automatically consumed by `/omni-plan` — no duplicate work.
+
+### Flow 4: "I want maximum quality on everything"
+```
+/omni-plan-nth                              Just run this
+```
+`/omni-plan-nth` is the top-level orchestrator. It will invoke `/deep-research`, `/auto-swarm-nth`, `/plan-ceo-review`, `/plan-eng-review`, `/security-audit`, and any other skill it needs. It loops until every dimension scores 10/10.
+
+### Flow 5: "Quick security check"
+```
+/security-audit                             7-domain OWASP/MITRE/NIST audit
+```
+
+### Flow 6: "Understand a codebase I didn't write"
+```
+Step 1: /learn-mode "walkthrough"            Interactive guided tour
+   — or —
+Step 1: /auto-swarm "reverse-engineer this codebase" --mode explore
+```
+
+### Flow 7: "Prepare for a code review / PR"
+```
+Step 1: /production-upgrade validate         Quick validation pass
+Step 2: Review .productionos/ output
+Step 3: Fix any findings
+Step 4: Commit and push
+```
+
+## How Commands Connect
+
+Commands produce artifacts in `.productionos/` that downstream commands consume:
+
+```
+/deep-research ──→ RESEARCH-*.md ──→ /omni-plan (skips re-research)
+/production-upgrade ──→ AUDIT-DISCOVERY.md ──→ /omni-plan (skips discovery)
+/omni-plan ──→ OMNI-PLAN.md ──→ /auto-swarm (task decomposition)
+/security-audit ──→ AUDIT-SECURITY.md ──→ /production-upgrade (security context)
+```
+
+**Rule: Never redo work.** If a prior command already produced findings, the next command should consume them.
+
+## The Orchestration Hierarchy
+
+```
+/omni-plan-nth (TOP — can invoke ANY command, loops until 10/10)
+    |
+    ├── /omni-plan (13-step pipeline per iteration)
+    │   └── /auto-swarm-nth (execution engine within iterations)
+    │       └── Each agent can invoke skills within its scope
+    |
+    ├── /deep-research (on-demand investigation)
+    ├── /security-audit (on-demand security check)
+    ├── /agentic-eval (on-demand quality evaluation)
+    └── External: /plan-ceo-review, /plan-eng-review, /qa, /browse, /ship
+```
+
+## Tips
+
+1. **Start with `/production-upgrade`** if you're unsure — it's the lightest pipeline
+2. **Use `/omni-plan-nth`** when you want maximum quality — it runs everything
+3. **Check `.productionos/`** after any command — all findings go there
+4. **Run `bun run skill:check`** to verify ProductionOS itself is healthy (100%)
+5. **Run `bun run dashboard`** to see which reviews have been completed
+6. **Use `/learn-mode`** to understand unfamiliar code before auditing it
+7. **The `-nth` variants** run until perfect — standard variants run once
+8. **External skills** (gstack, superpowers) enhance capabilities but aren't required
+
+## Validation Commands
+
+```bash
+bun run skill:check      # Health dashboard (should report 100%)
+bun run validate          # Agent frontmatter validation (78/78)
+bun run audit:context     # Token budget tracking
+bun run dashboard         # Review readiness per branch
+bun test                  # Automated test suite (118 tests)
+```
+
+## Getting Help
+
+- **CLAUDE.md** — Auto-loaded instructions and command reference
+- **ARCHITECTURE.md** — Why decisions were made (with implementation status)
+- **CONTRIBUTING.md** — How to add agents and commands
+- **CHANGELOG.md** — What changed in each version
+- **TODOS.md** — Known gaps and planned improvements
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| No target provided | Ask for clarification with examples |
+| Target not found | Search for alternatives, suggest closest match |
+| Missing dependencies | Report what is needed and how to install |
+| Permission denied | Check file permissions, suggest fix |
+| State file corrupted | Reset to defaults, report what was lost |
 
 ## Guardrails
 
-- Do not claim that Claude-only marketplace, hook, or slash-command behavior runs directly in Codex.
-- Keep the scope faithful to the source command rather than broadening into a generic repo audit.
-- Prefer concrete outputs and validation over describing the workflow abstractly.
-- Preserve the scope and stop conditions from the source command rather than broadening into a generic repo audit.
+1. Do not silently change scope or expand beyond the user request.
+2. Prefer concrete outputs and verification over abstract descriptions.
+3. Keep scope faithful to the user intent.
+4. Preserve existing workflow guardrails and stop conditions.
+5. Verify results before concluding.

--- a/skills/productionos-pause/SKILL.md
+++ b/skills/productionos-pause/SKILL.md
@@ -6,49 +6,82 @@ argument-hint: "[repo path, target, or task context]"
 
 # productionos-pause
 
-## Overview
-
-This is the Codex-native workflow wrapper for [.claude/commands/productionos-pause.md](../../.claude/commands/productionos-pause.md).
-
-Use it when the user wants this exact ProductionOS workflow, not just the umbrella `productionos` router.
-
-## Source of Truth
-
-1. Read the source command spec at [.claude/commands/productionos-pause.md](../../.claude/commands/productionos-pause.md).
-2. Use [CODEX-PARITY-HANDOFF.md](../../docs/CODEX-PARITY-HANDOFF.md) to confirm runtime support and parity expectations.
-3. Preserve the source workflow's guardrails, scope, artifacts, and verification intent.
-4. Translate Claude-only slash-command and hook semantics into Codex-native execution instead of copying them literally.
-
-## Codex Behavior
-
-- Summary: Save current pipeline state for later resumption. Creates a checkpoint at .productionos/CHECKPOINT.json with all active context.
-- Use the source command as the behavioral spec, then execute the same intent with Codex-native tools and constraints.
+Save current pipeline state for later resumption. Creates a checkpoint at .productionos/CHECKPOINT.json with all active context.
 
 ## Inputs
 
-- No explicit arguments. Use repo path, target, or task context as needed.
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `target` | path or context | cwd | What to operate on |
 
-## Execution Outline
+# ProductionOS Pause — Save Pipeline State
 
-1. Follow the source command sections in order and preserve its exit criteria.
+Save the current pipeline state so work can be resumed in a new session.
 
-## Agents And Assets
+## What Gets Saved
 
-- Agents: no explicit agent references in the source command.
-- Templates: no explicit shared templates beyond general repo conventions.
-- Artifacts: `.productionos/CHECKPOINT.json`, `.productionos/CONVERGENCE-DATA.json`, `.productionos/CONVERGENCE-LOG.md`
+Write `.productionos/CHECKPOINT.json`:
 
-## Workflow
+```json
+{
+  "command": "<active command name>",
+  "step": "<current step number and name>",
+  "iteration": "<current iteration if recursive>",
+  "timestamp": "<ISO 8601>",
+  "grade": {
+    "before": "<BEFORE grade if available>",
+    "current": "<latest grade>"
+  },
+  "artifacts": ["<list of .productionos/*.md files that exist>"],
+  "uncommitted_files": ["<output of git diff --name-only>"],
+  "pending_batches": "<number of unexecuted batches if mid-execution>",
+  "context_notes": "<brief description of what was happening>"
+}
+```
 
-1. Load only the agents, templates, prompts, and docs referenced by the source command.
-2. Execute the workflow intent with Codex-native tools.
-3. If the source command implies parallel agent work, only delegate when the user explicitly wants that overhead.
-4. Verify with the smallest relevant checks before concluding.
-5. Summarize what changed, what was verified, and what still needs human approval.
+## Execution
+
+1. Detect the active pipeline state:
+   - Read `.productionos/CONVERGENCE-LOG.md` for iteration history
+   - Read `.productionos/CONVERGENCE-DATA.json` for current scores
+   - Check `git status` for uncommitted work
+   - Count remaining batches from `OMNI-PLAN.md` or `UPGRADE-PLAN.md`
+
+2. Write the checkpoint file
+
+3. Display confirmation:
+```
+[ProductionOS] Pipeline paused.
+  Command: {command}
+  Step: {step}
+  Grade: {current_grade}
+  Uncommitted: {N} files
+
+  Resume with: /productionos-resume
+```
+
+4. Do NOT commit or push — preserve the working state exactly as-is
+
+## Notes
+
+- This is a lightweight state save, not a full context serialization
+- The checkpoint is sufficient for a new session to pick up where this one left off
+- Resume reads the checkpoint and routes to the appropriate command step
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| No target provided | Ask for clarification with examples |
+| Target not found | Search for alternatives, suggest closest match |
+| Missing dependencies | Report what is needed and how to install |
+| Permission denied | Check file permissions, suggest fix |
+| State file corrupted | Reset to defaults, report what was lost |
 
 ## Guardrails
 
-- Do not claim that Claude-only marketplace, hook, or slash-command behavior runs directly in Codex.
-- Keep the scope faithful to the source command rather than broadening into a generic repo audit.
-- Prefer concrete outputs and validation over describing the workflow abstractly.
-- Preserve the scope and stop conditions from the source command rather than broadening into a generic repo audit.
+1. Do not silently change scope or expand beyond the user request.
+2. Prefer concrete outputs and verification over abstract descriptions.
+3. Keep scope faithful to the user intent.
+4. Preserve existing workflow guardrails and stop conditions.
+5. Verify results before concluding.

--- a/skills/productionos-resume/SKILL.md
+++ b/skills/productionos-resume/SKILL.md
@@ -6,49 +6,73 @@ argument-hint: "[repo path, target, or task context]"
 
 # productionos-resume
 
-## Overview
-
-This is the Codex-native workflow wrapper for [.claude/commands/productionos-resume.md](../../.claude/commands/productionos-resume.md).
-
-Use it when the user wants this exact ProductionOS workflow, not just the umbrella `productionos` router.
-
-## Source of Truth
-
-1. Read the source command spec at [.claude/commands/productionos-resume.md](../../.claude/commands/productionos-resume.md).
-2. Use [CODEX-PARITY-HANDOFF.md](../../docs/CODEX-PARITY-HANDOFF.md) to confirm runtime support and parity expectations.
-3. Preserve the source workflow's guardrails, scope, artifacts, and verification intent.
-4. Translate Claude-only slash-command and hook semantics into Codex-native execution instead of copying them literally.
-
-## Codex Behavior
-
-- Summary: Resume a paused pipeline from .productionos/CHECKPOINT.json. Restores context and routes to the correct step.
-- Use the source command as the behavioral spec, then execute the same intent with Codex-native tools and constraints.
+Resume a paused pipeline from .productionos/CHECKPOINT.json. Restores context and routes to the correct step.
 
 ## Inputs
 
-- No explicit arguments. Use repo path, target, or task context as needed.
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `target` | path or context | cwd | What to operate on |
 
-## Execution Outline
+# ProductionOS Resume — Restore Pipeline State
 
-1. Follow the source command sections in order and preserve its exit criteria.
+Resume work from a previously paused pipeline.
 
-## Agents And Assets
+## Execution
 
-- Agents: no explicit agent references in the source command.
-- Templates: no explicit shared templates beyond general repo conventions.
-- Artifacts: `.productionos/CHECKPOINT.json`, `.productionos/CHECKPOINT.json.`
+1. **Read checkpoint:**
+   ```
+   Read .productionos/CHECKPOINT.json
+   If not found: "No checkpoint found. Start a new pipeline with /production-upgrade or /omni-plan."
+   ```
 
-## Workflow
+2. **Validate state:**
+   - Check that all listed artifacts still exist
+   - Compare `git diff --name-only` with saved `uncommitted_files`
+   - If divergence detected: warn but don't halt
+     `"WARNING: Working tree has changed since pause. {N} new files, {M} missing files."`
 
-1. Load only the agents, templates, prompts, and docs referenced by the source command.
-2. Execute the workflow intent with Codex-native tools.
-3. If the source command implies parallel agent work, only delegate when the user explicitly wants that overhead.
-4. Verify with the smallest relevant checks before concluding.
-5. Summarize what changed, what was verified, and what still needs human approval.
+3. **Display status:**
+   ```
+   [ProductionOS] Resuming pipeline.
+     Command: {command}
+     Paused at: {step} ({timestamp})
+     Grade: {before} → {current}
+     Artifacts: {N} files in .productionos/
+     Uncommitted: {N} files
+   ```
+
+4. **Route to command:**
+   - Parse the `command` and `step` fields
+   - Invoke the appropriate command with a `--resume-from` context:
+     - `/omni-plan` → resume from the saved step number
+     - `/production-upgrade` → resume from the saved step
+     - `/auto-swarm` → resume with remaining coverage gaps
+   - Pass all existing `.productionos/` artifacts as prior work (the Preamble's artifact reuse check handles this)
+
+5. **Clean up:**
+   - After successful resumption (pipeline reaches completion or next pause): delete CHECKPOINT.json
+   - If the resumed pipeline fails: keep CHECKPOINT.json for retry
+
+## Notes
+
+- Resume is NOT a full context restoration — it provides enough state for the pipeline to skip completed steps
+- The Preamble's "Prior work check" (Step 0B) already handles artifact reuse, so most of the context recovery is automatic
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| No target provided | Ask for clarification with examples |
+| Target not found | Search for alternatives, suggest closest match |
+| Missing dependencies | Report what is needed and how to install |
+| Permission denied | Check file permissions, suggest fix |
+| State file corrupted | Reset to defaults, report what was lost |
 
 ## Guardrails
 
-- Do not claim that Claude-only marketplace, hook, or slash-command behavior runs directly in Codex.
-- Keep the scope faithful to the source command rather than broadening into a generic repo audit.
-- Prefer concrete outputs and validation over describing the workflow abstractly.
-- Preserve the scope and stop conditions from the source command rather than broadening into a generic repo audit.
+1. Do not silently change scope or expand beyond the user request.
+2. Prefer concrete outputs and verification over abstract descriptions.
+3. Keep scope faithful to the user intent.
+4. Preserve existing workflow guardrails and stop conditions.
+5. Verify results before concluding.

--- a/skills/productionos-stats/SKILL.md
+++ b/skills/productionos-stats/SKILL.md
@@ -6,50 +6,79 @@ argument-hint: "[repo path, target, or task context]"
 
 # productionos-stats
 
-## Overview
-
-This is the Codex-native workflow wrapper for [.claude/commands/productionos-stats.md](../../.claude/commands/productionos-stats.md).
-
-Use it when the user wants this exact ProductionOS workflow, not just the umbrella `productionos` router.
-
-## Source of Truth
-
-1. Read the source command spec at [.claude/commands/productionos-stats.md](../../.claude/commands/productionos-stats.md).
-2. Use [CODEX-PARITY-HANDOFF.md](../../docs/CODEX-PARITY-HANDOFF.md) to confirm runtime support and parity expectations.
-3. Preserve the source workflow's guardrails, scope, artifacts, and verification intent.
-4. Translate Claude-only slash-command and hook semantics into Codex-native execution instead of copying them literally.
-
-## Codex Behavior
-
-- Summary: Display ProductionOS system statistics — agent count, command count, hook count, test count, version, instinct count, and session history.
-- Use the source command as the behavioral spec, then execute the same intent with Codex-native tools and constraints.
+Display ProductionOS system statistics — agent count, command count, hook count, test count, version, instinct count, and session history.
 
 ## Inputs
 
-- No explicit arguments. Use repo path, target, or task context as needed.
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `target` | path or context | cwd | What to operate on |
 
-## Execution Outline
+# /productionos-stats — System Dashboard
 
-1. Preamble
-2. Run Stats Dashboard
+Display a comprehensive stats dashboard for the current ProductionOS installation.
 
-## Agents And Assets
+## Step 0: Preamble
 
-- Agents: no explicit agent references in the source command.
-- Templates: `PREAMBLE.md`
-- Artifacts: no explicit `.productionos/` artifacts called out in the source command.
+Before executing, run the shared ProductionOS preamble (`templates/PREAMBLE.md`).
 
-## Workflow
+## Step 1: Run Stats Dashboard
 
-1. Load only the agents, templates, prompts, and docs referenced by the source command.
-2. Execute the workflow intent with Codex-native tools.
-3. If the source command implies parallel agent work, only delegate when the user explicitly wants that overhead.
-4. Verify with the smallest relevant checks before concluding.
-5. Summarize what changed, what was verified, and what still needs human approval.
+Execute the stats dashboard script:
+
+```bash
+bun run scripts/stats-dashboard.ts
+```
+
+The script computes and outputs all metrics in structured markdown format.
+
+## Metrics Computed
+
+### System Metrics
+- **Version** — from `VERSION` file
+- **Agent count** — total `.md` files in `agents/` with HIGH/MEDIUM/LOW stakes breakdown
+- **Command count** — total `.md` files in `.claude/commands/`
+- **Hook count** — unique hook scripts referenced in `hooks/hooks.json`
+- **Template count** — total `.md` files in `templates/`
+- **Script count** — total `.ts` files in `scripts/`
+- **Test file count** — total `.ts` files in `tests/`
+
+### Learning Metrics
+- **Project instincts** — patterns learned for the current project
+- **Global instincts** — cross-project patterns (confidence > 0.8)
+- **Session handoffs** — auto-generated handoff documents
+- **Skill usage events** — total events in analytics log
+
+### Git Activity
+- **Total commits** — `git rev-list --count HEAD`
+- **Commits today** — `git log --oneline --since=midnight`
+- **Last handoff** — most recent session handoff document
+
+## Output Format
+
+The dashboard outputs a markdown table for each category, suitable for display in Claude Code's conversation.
+
+## Use Cases
+
+- Run after a sprint to see what was shipped (new agents, commands, hooks)
+- Check learning progress (instinct accumulation across sessions)
+- Verify installation completeness (all counts match expected values)
+- Share stats in session handoff documents for continuity
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| No target provided | Ask for clarification with examples |
+| Target not found | Search for alternatives, suggest closest match |
+| Missing dependencies | Report what is needed and how to install |
+| Permission denied | Check file permissions, suggest fix |
+| State file corrupted | Reset to defaults, report what was lost |
 
 ## Guardrails
 
-- Do not claim that Claude-only marketplace, hook, or slash-command behavior runs directly in Codex.
-- Keep the scope faithful to the source command rather than broadening into a generic repo audit.
-- Prefer concrete outputs and validation over describing the workflow abstractly.
-- Preserve the scope and stop conditions from the source command rather than broadening into a generic repo audit.
+1. Do not silently change scope or expand beyond the user request.
+2. Prefer concrete outputs and verification over abstract descriptions.
+3. Keep scope faithful to the user intent.
+4. Preserve existing workflow guardrails and stop conditions.
+5. Verify results before concluding.

--- a/skills/productionos-update/SKILL.md
+++ b/skills/productionos-update/SKILL.md
@@ -6,39 +6,167 @@ argument-hint: "[repo path or install context]"
 
 # productionos-update
 
-## Overview
-
-Use this as the Codex-first self-update workflow for local ProductionOS installs. It should discover where ProductionOS is installed, compare local versus remote state, update safely, and sync the installed surfaces for Claude and Codex.
-
-Source references:
-- `.claude/commands/productionos-update.md`
-- `bin/install.cjs`
+Update ProductionOS plugin to the latest version from GitHub
 
 ## Inputs
 
-- local repo or installation path
-- optional target runtime: Claude, Codex, or both
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `target` | path or context | cwd | What to operate on |
 
-## Codex Workflow
+# ProductionOS Self-Update
 
-1. Detect the current installation layout.
-   - local repo
-   - Claude install
-   - Codex install
-2. Inspect the current version and compare against the remote source.
-3. Show the changelog delta before updating.
-4. Update the repo and then re-sync installed surfaces.
-5. Verify the final version and installed artifacts.
+You are the update mechanism for the ProductionOS plugin.
 
-## Expected Output
+## Step 0: Preamble
 
-- current version
-- available update summary
-- synced install targets
-- final installed version
+Before executing, run the shared ProductionOS preamble (`templates/PREAMBLE.md`):
+1. **Environment check** — version, agent count, stack detection
+2. **Prior work check** — read `.productionos/` for existing output
+3. **Success criteria** — successful update to latest version
+
+## Update Protocol
+
+### Step 1: Detect Current Installation
+```bash
+# Find where ProductionOS is installed
+INSTALL_DIR=""
+CODEX_PLUGIN_DIR=""
+
+# Check marketplace installation
+if [ -d "$HOME/.claude/plugins/marketplaces/productionos" ]; then
+  INSTALL_DIR="$HOME/.claude/plugins/marketplaces/productionos"
+fi
+
+# Check Codex plugin installation
+if [ -d "$HOME/.codex/plugins/productionos" ]; then
+  CODEX_PLUGIN_DIR="$HOME/.codex/plugins/productionos"
+fi
+
+# Check local repo
+if [ -d "$HOME/ProductionOS" ]; then
+  REPO_DIR="$HOME/ProductionOS"
+fi
+```
+
+Read the current version from:
+1. `$INSTALL_DIR/.claude-plugin/plugin.json` → `.version` field
+2. `$REPO_DIR/VERSION` if exists
+3. Report current version to user
+
+### Step 2: Check for Updates
+```bash
+# Fetch latest from GitHub without merging
+cd "$REPO_DIR" 2>/dev/null || cd "$INSTALL_DIR"
+git fetch origin main 2>/dev/null
+
+# Compare versions
+LOCAL_VERSION=$(cat VERSION 2>/dev/null || jq -r .version .claude-plugin/plugin.json)
+REMOTE_LOG=$(git log origin/main --oneline -10 2>/dev/null)
+```
+
+If no git repo found, inform user:
+```
+ProductionOS is not installed from git.
+To install the updatable version:
+  git clone https://github.com/ShaheerKhawaja/ProductionOS.git ~/ProductionOS
+  claude plugin install productionos
+```
+
+### Step 3: Show Changelog
+Show the user what changed:
+```bash
+git log HEAD..origin/main --oneline --no-merges 2>/dev/null
+```
+
+If there are changes, show:
+```
+ProductionOS Update Available
+───────────────────────────────
+Current: vX.Y.Z
+Latest:  vA.B.C
+
+Changes:
+  - commit message 1
+  - commit message 2
+  ...
+
+Update now? (This will pull latest changes)
+```
+
+### Step 4: Apply Update
+If user confirms (or running in auto mode):
+```bash
+cd "$REPO_DIR"
+git pull origin main
+```
+
+### Step 5: Sync Installations
+After pulling, sync to all installation locations:
+```bash
+# Sync to marketplace plugin directory
+if [ -d "$HOME/.claude/plugins/marketplaces/productionos" ]; then
+  rsync -av --update \
+    --exclude='.git' \
+    "$REPO_DIR/" "$HOME/.claude/plugins/marketplaces/productionos/"
+  echo "Synced to marketplace installation"
+fi
+
+# Sync Codex plugin installation
+if [ -d "$HOME/.codex/plugins/productionos" ]; then
+  rsync -av --update \
+    --exclude='.git' \
+    "$REPO_DIR/" "$HOME/.codex/plugins/productionos/"
+  echo "Synced Codex plugin installation"
+fi
+
+# Sync command files
+if [ -d "$HOME/.claude/commands" ]; then
+  for cmd in "$REPO_DIR/.claude/commands/"*.md; do
+    cp "$cmd" "$HOME/.claude/commands/$(basename $cmd)"
+  done
+  echo "Synced commands"
+fi
+```
+
+### Step 6: Verify
+```bash
+NEW_VERSION=$(cat "$REPO_DIR/VERSION" 2>/dev/null || jq -r .version "$REPO_DIR/.claude-plugin/plugin.json")
+echo "Updated to v${NEW_VERSION}"
+```
+
+Report:
+```
+ProductionOS Updated Successfully
+────────────────────────────────────
+Previous: vX.Y.Z
+Current:  vA.B.C
+Files synced: marketplace, Codex plugin, commands
+```
+
+## Rollback
+If update breaks something:
+```bash
+cd ~/ProductionOS
+git log --oneline -5  # Find the commit to roll back to
+git reset --hard <commit>  # Roll back
+# Then re-run sync steps
+```
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| No target provided | Ask for clarification with examples |
+| Target not found | Search for alternatives, suggest closest match |
+| Missing dependencies | Report what is needed and how to install |
+| Permission denied | Check file permissions, suggest fix |
+| State file corrupted | Reset to defaults, report what was lost |
 
 ## Guardrails
 
-- do not reset or overwrite local work without approval
-- report network or auth blockers clearly
-- verify installed surfaces after update instead of assuming sync succeeded
+1. Do not silently change scope or expand beyond the user request.
+2. Prefer concrete outputs and verification over abstract descriptions.
+3. Keep scope faithful to the user intent.
+4. Preserve existing workflow guardrails and stop conditions.
+5. Verify results before concluding.

--- a/skills/qa-only/SKILL.md
+++ b/skills/qa-only/SKILL.md
@@ -6,50 +6,52 @@ argument-hint: "[repo path, target, or task context]"
 
 # qa-only
 
-## Overview
-
-This is the Codex-native workflow wrapper for [.claude/commands/qa-only.md](../../.claude/commands/qa-only.md).
-
-Use it when the user wants this exact ProductionOS workflow, not just the umbrella `productionos` router.
-
-## Source of Truth
-
-1. Read the source command spec at [.claude/commands/qa-only.md](../../.claude/commands/qa-only.md).
-2. Use [CODEX-PARITY-HANDOFF.md](../../docs/CODEX-PARITY-HANDOFF.md) to confirm runtime support and parity expectations.
-3. Preserve the source workflow's guardrails, scope, artifacts, and verification intent.
-4. Translate Claude-only slash-command and hook semantics into Codex-native execution instead of copying them literally.
-
-## Codex Behavior
-
-- Summary: Report-only QA testing — produces structured report with health score, screenshots, and repro steps. No fixes applied.
-- Use the source command as the behavioral spec, then execute the same intent with Codex-native tools and constraints.
+Report-only QA testing — produces structured report with health score, screenshots, and repro steps. No fixes applied.
 
 ## Inputs
 
-- `url` — URL to test Optional.
-- `mode` — Mode: full | smoke (default: full) Default: `full` Optional.
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `url` | string | -- | URL to test |
+| `mode` | string | full | Mode: full | smoke (default: full) |
 
-## Execution Outline
+# /qa-only — Report-Only QA Testing
 
-1. Preamble
+Same methodology as `/qa` but strictly read-only. No fixes. No code changes. Report only.
 
-## Agents And Assets
+## Step 0: Preamble
+Run `templates/PREAMBLE.md`.
 
-- Agents: no explicit agent references in the source command.
-- Templates: `PREAMBLE.md`, `SELF-EVAL-PROTOCOL.md`
-- Artifacts: `.productionos/QA-ONLY-{timestamp}.md`
+## Execution
+Follow the same Steps 1-4 as `/qa` (discover, smoke, deep QA, health score).
 
-## Workflow
+**HARD-GATE: Do NOT dispatch any agent with Write or Edit tools. This is a READ-ONLY audit.**
 
-1. Load only the agents, templates, prompts, and docs referenced by the source command.
-2. Execute the workflow intent with Codex-native tools.
-3. If the source command implies parallel agent work, only delegate when the user explicitly wants that overhead.
-4. Verify with the smallest relevant checks before concluding.
-5. Summarize what changed, what was verified, and what still needs human approval.
+## Output
+Write report to `.productionos/QA-ONLY-{timestamp}.md` with:
+- Health score (0-100)
+- Screenshots of every page
+- Bug list with severity, repro steps, and file:line references
+- Accessibility findings
+- Performance metrics
+
+## Self-Eval
+Run `templates/SELF-EVAL-PROTOCOL.md` on report completeness and evidence quality.
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| No target provided | Ask for clarification with examples |
+| Target not found | Search for alternatives, suggest closest match |
+| Missing dependencies | Report what is needed and how to install |
+| Permission denied | Check file permissions, suggest fix |
+| State file corrupted | Reset to defaults, report what was lost |
 
 ## Guardrails
 
-- Do not claim that Claude-only marketplace, hook, or slash-command behavior runs directly in Codex.
-- Keep the scope faithful to the source command rather than broadening into a generic repo audit.
-- Prefer concrete outputs and validation over describing the workflow abstractly.
-- Preserve the scope and stop conditions from the source command rather than broadening into a generic repo audit.
+1. Do not silently change scope or expand beyond the user request.
+2. Prefer concrete outputs and verification over abstract descriptions.
+3. Keep scope faithful to the user intent.
+4. Preserve existing workflow guardrails and stop conditions.
+5. Verify results before concluding.

--- a/tests/runtime-targets.test.ts
+++ b/tests/runtime-targets.test.ts
@@ -29,6 +29,14 @@ const HAND_CRAFTED_SKILLS = new Set([
   "debug",
   "brainstorming",
   "document-release",
+  "devtools",
+  "productionos-help",
+  "productionos-pause",
+  "productionos-resume",
+  "productionos-stats",
+  "productionos-update",
+  "autoloop",
+  "qa-only",
 ]);
 
 describe("runtime target generation", () => {
@@ -142,8 +150,7 @@ describe("runtime target generation", () => {
       "deep-research",
       "auto-swarm",
       "ux-genie",
-      "productionos-update",
-    ];
+      ];
 
     for (const skillName of autoGenCoreSkills) {
       const skill = getGeneratedTargetFiles().find((file) => file.path === `skills/${skillName}/SKILL.md`);
@@ -163,7 +170,7 @@ describe("runtime target generation", () => {
     }
 
     // Hand-crafted dense runbooks exist on disk, not in auto-generated targets
-    const handCraftedCoreSkills = ["omni-plan", "designer-upgrade", "plan-ceo-review", "auto-optimize", "learn-mode", "build-productionos", "qa", "browse", "plan-eng-review", "debug", "brainstorming", "document-release"];
+    const handCraftedCoreSkills = ["omni-plan", "designer-upgrade", "plan-ceo-review", "auto-optimize", "learn-mode", "build-productionos", "qa", "browse", "plan-eng-review", "debug", "brainstorming", "document-release", "devtools", "productionos-help", "productionos-pause", "productionos-resume", "productionos-stats", "productionos-update", "autoloop", "qa-only"];
     for (const skillName of handCraftedCoreSkills) {
       expect(HAND_CRAFTED_SKILLS.has(skillName)).toBe(true);
       const content = readFileOrNull(join(ROOT, "skills", skillName, "SKILL.md"));


### PR DESCRIPTION
## Summary
- Upgrade 10 infrastructure skills from thin stubs to self-contained runbooks
- Add 8 skills to HAND_CRAFTED_SKILLS (exempt from auto-generation)
- Graduate productionos-update from autoGenCoreSkills to handCraftedCoreSkills

### Skills upgraded
devtools, productionos, productionos-help, productionos-pause, productionos-resume, productionos-stats, productionos-update, autoloop, qa-only, interface-craft

## Test plan
- [ ] `bun test` — 967+ pass, 0 fail
- [ ] `npx tsc --noEmit` — 0 errors
- [ ] Verify each upgraded SKILL.md has `## Inputs` and `## Guardrails`