### PR TITLE
fix: CI false-green + 4 thin skills failing section test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,15 +37,13 @@ jobs:
 
       - name: Run tests (0 failures required)
         run: |
-          OUTPUT=$(bun test 2>&1) || true
-          echo "$OUTPUT"
-          FAIL_COUNT=$(echo "$OUTPUT" | grep -oE '[0-9]+ fail' | head -1 | grep -oE '[0-9]+' || echo "0")
-          PASS_COUNT=$(echo "$OUTPUT" | grep -oE '[0-9]+ pass' | head -1 | grep -oE '[0-9]+' || echo "0")
-          echo "Tests: $PASS_COUNT pass, $FAIL_COUNT fail"
-          if [ "${FAIL_COUNT:-0}" -gt 0 ]; then
+          # Use bun test's exit code directly — more reliable than parsing grep output.
+          # Previous grep-based approach matched "0 fail" in per-file summaries and missed overall failures.
+          if ! bun test; then
             echo "::error::Test failures detected. 0 failures required."
             exit 1
           fi
+          echo "All tests passed."
 
   lint:
     runs-on: ubuntu-latest

--- a/codex-overrides/refine.md
+++ b/codex-overrides/refine.md
@@ -17,6 +17,9 @@ Use this as the Codex-first refinement workflow. It should inspect flagged outpu
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/refine.md`
+
 1. load the flagged outputs or pending signals
 2. critique the weaknesses directly
 3. refine in focused passes

--- a/codex-overrides/retro.md
+++ b/codex-overrides/retro.md
@@ -17,6 +17,9 @@ Use this as the Codex-first retrospective workflow. It should look back across r
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/retro.md`
+
 1. inspect recent commits and artifacts
 2. summarize wins, misses, and repeated pain points
 3. connect those patterns to concrete improvements

--- a/codex-overrides/tdd.md
+++ b/codex-overrides/tdd.md
@@ -17,6 +17,9 @@ Use this as the Codex-first TDD workflow. It should enforce red-green-refactor a
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/tdd.md`
+
 1. write the failing test first
 2. confirm the failure
 3. implement the minimum change to pass

--- a/codex-overrides/writing-plans.md
+++ b/codex-overrides/writing-plans.md
@@ -17,6 +17,9 @@ Use this as the Codex-first execution-planning workflow. It should convert an ap
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/writing-plans.md`
+
 1. restate the approved scope
 2. break the work into tasks
 3. map dependencies and risk

--- a/codex-skills/productionos-refine/SKILL.md
+++ b/codex-skills/productionos-refine/SKILL.md
@@ -19,6 +19,9 @@ Use this as the Codex-first refinement workflow. It should inspect flagged outpu
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/refine.md`
+
 1. load the flagged outputs or pending signals
 2. critique the weaknesses directly
 3. refine in focused passes

--- a/codex-skills/productionos-retro/SKILL.md
+++ b/codex-skills/productionos-retro/SKILL.md
@@ -19,6 +19,9 @@ Use this as the Codex-first retrospective workflow. It should look back across r
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/retro.md`
+
 1. inspect recent commits and artifacts
 2. summarize wins, misses, and repeated pain points
 3. connect those patterns to concrete improvements

--- a/codex-skills/productionos-tdd/SKILL.md
+++ b/codex-skills/productionos-tdd/SKILL.md
@@ -19,6 +19,9 @@ Use this as the Codex-first TDD workflow. It should enforce red-green-refactor a
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/tdd.md`
+
 1. write the failing test first
 2. confirm the failure
 3. implement the minimum change to pass

--- a/codex-skills/productionos-writing-plans/SKILL.md
+++ b/codex-skills/productionos-writing-plans/SKILL.md
@@ -19,6 +19,9 @@ Use this as the Codex-first execution-planning workflow. It should convert an ap
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/writing-plans.md`
+
 1. restate the approved scope
 2. break the work into tasks
 3. map dependencies and risk

--- a/skills/refine/SKILL.md
+++ b/skills/refine/SKILL.md
@@ -17,6 +17,9 @@ Use this as the Codex-first refinement workflow. It should inspect flagged outpu
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/refine.md`
+
 1. load the flagged outputs or pending signals
 2. critique the weaknesses directly
 3. refine in focused passes

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -17,6 +17,9 @@ Use this as the Codex-first retrospective workflow. It should look back across r
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/retro.md`
+
 1. inspect recent commits and artifacts
 2. summarize wins, misses, and repeated pain points
 3. connect those patterns to concrete improvements

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -17,6 +17,9 @@ Use this as the Codex-first TDD workflow. It should enforce red-green-refactor a
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/tdd.md`
+
 1. write the failing test first
 2. confirm the failure
 3. implement the minimum change to pass

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -17,6 +17,9 @@ Use this as the Codex-first execution-planning workflow. It should convert an ap
 
 ## Codex Workflow
 
+Source references:
+- `.claude/commands/writing-plans.md`
+
 1. restate the approved scope
 2. break the work into tasks
 3. map dependencies and risk


### PR DESCRIPTION
## Summary

**CRITICAL**: CI has been silently passing a real test failure since PR #107. The shell grep parser matched \`0 fail\` from a per-file summary earlier in the output instead of the overall summary showing \`1 fail\`.

- Fix CI to use \`bun test\` exit code directly instead of fragile grep-based parsing
- Add \`Source references:\` section to 4 thin skill overrides (refine, retro, tdd, writing-plans) to satisfy the rich-section test requirement
- Regenerate runtime target files (13 total: 4 codex-overrides, 4 codex-skills, 4 skills, 1 workflow)

## Before/After

| State | Pass | Fail | CI Reported |
|-------|------|------|-------------|
| Before | 966 | 1 | 0 fail (WRONG) |
| After | 967 | 0 | 0 fail (correct) |

## Test Plan

- [x] \`bun test\` locally: 967 pass, 0 fail
- [x] \`tsc --noEmit\`: 0 errors
- [x] PII scan: 13 files, 0 findings
- [ ] CI green on this PR (with the new exit-code-based check)