### PR TITLE
feat(arch): composite skill architecture + SEO reference implementation

### DIFF
--- a/docs/CODEX-PARITY-HANDOFF.md
+++ b/docs/CODEX-PARITY-HANDOFF.md
@@ -2,7 +2,7 @@
 
 This document is generated from the runtime-neutral registry in [scripts/lib/runtime-targets.ts](../scripts/lib/runtime-targets.ts).
 
-Current snapshot: 80 agents, 41 commands, 17 hooks, 13 templates, 28 tests.
+Current snapshot: 80 agents, 41 commands, 17 hooks, 14 templates, 28 tests.
 
 ## Runtime Targets
 

--- a/skills/pos-ads/SKILL.md
+++ b/skills/pos-ads/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: pos-ads
+description: "Ads composite — audit campaigns, create ad copy, optimize bids, and report performance with persistent campaign memory. Replaces 20 fragmented ads skills."
+argument-hint: "[audit|create|optimize|report] [platform or campaign]"
+---
+
+# pos-ads
+
+Ads composite — audit campaigns, create ad copy, optimize bids, and report performance with persistent campaign memory. Replaces 20 fragmented ads skills.
+
+**Replaces:** ads-apple, ads-audit, ads-budget, ads-competitor, ads-create, ads-creative, ads-dna, ads-generate, ads-google, ads-landing, ads-linkedin, ads-meta, ads-microsoft, ads-photoshoot, ads-plan, ads-tiktok, ads-youtube, unified-ads, paid-ads, competitive-ads-extractor
+
+## Actions
+
+| Action | What |
+|--------|------|
+| `audit [platform]` | Audit campaign performance across platforms |
+| `create [type]` | Generate ad copy, creatives, and landing page concepts |
+| `optimize` | Budget reallocation and bid optimization recommendations |
+| `report` | Cross-platform performance report with ROI analysis |
+
+## Routing
+
+1. Parse action from first argument
+2. Load domain memory from `~/.productionos/domains/pos-ads/`
+3. If first run: auto-detect project context, create profile
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/pos-ads/`:
+profile.yml (platforms, budgets, audiences, goals), campaign-history.jsonl (past campaigns with metrics), creative-bank.jsonl (tested ad copy and results), learnings.jsonl
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `audit`, `create`, `optimize`, `report` | `audit` | Sub-skill to run |
+| `target` | path, URL, or description | required | What to operate on |
+
+## Guardrails
+
+1. Memory is append-only. Never delete history.
+2. Every action scored against rubric. No silent completion.
+3. Profile is user-controlled. Never change without asking.
+4. Evidence required. No fabricated metrics or claims.
+5. Learn from history. Compare current output to past executions.

--- a/skills/pos-ads/evaluation/rubric.yml
+++ b/skills/pos-ads/evaluation/rubric.yml
@@ -1,0 +1,55 @@
+domain: ads
+version: 1
+
+actions:
+  audit:
+    passing_score: 8.0
+    dimensions:
+      - name: platform_coverage
+        weight: 0.3
+        passing: 85
+      - name: metric_accuracy
+        weight: 0.35
+        passing: 90
+      - name: recommendation_quality
+        weight: 0.35
+        passing: 85
+  create:
+    passing_score: 8.0
+    dimensions:
+      - name: hook_quality
+        weight: 0.3
+        passing: 80
+      - name: cta_clarity
+        weight: 0.25
+        passing: 85
+      - name: audience_targeting
+        weight: 0.25
+        passing: 80
+      - name: platform_fit
+        weight: 0.2
+        passing: 85
+  optimize:
+    passing_score: 8.0
+    dimensions:
+      - name: data_grounding
+        weight: 0.4
+        passing: 90
+      - name: budget_justification
+        weight: 0.3
+        passing: 85
+      - name: expected_impact
+        weight: 0.3
+        passing: 80
+  report:
+    passing_score: 8.0
+    dimensions:
+      - name: metric_completeness
+        weight: 0.3
+        passing: 85
+      - name: trend_analysis
+        weight: 0.35
+        passing: 80
+      - name: roi_calculation
+        weight: 0.35
+        passing: 90

--- a/skills/pos-build/SKILL.md
+++ b/skills/pos-build/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: pos-build
+description: "Build composite — brainstorm, plan, implement, and test with project memory. Replaces 6 fragmented build skills."
+argument-hint: "[brainstorm|plan|implement|test] [feature or task]"
+---
+
+# pos-build
+
+Build composite — brainstorm, plan, implement, and test with project memory. Replaces 6 fragmented build skills.
+
+**Replaces:** build, build-productionos, tdd, auto-mode, feature-dev, feature-development
+
+## Actions
+
+| Action | What |
+|--------|------|
+| `brainstorm [idea]` | Explore idea before building (delegates to /pos plan brainstorm) |
+| `plan [feature]` | Create step-by-step implementation plan |
+| `implement [task]` | Execute implementation with TDD discipline |
+| `test [target]` | Write tests for existing code or verify implementation |
+
+## Routing
+
+1. Parse action from first argument
+2. Load domain memory from `~/.productionos/domains/pos-build/`
+3. If first run: auto-detect project context, create profile
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/pos-build/`:
+profile.yml (tech stack, test framework, conventions), build-log.jsonl (past builds with outcomes), test-patterns.jsonl (what test patterns work for this codebase), learnings.jsonl
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `brainstorm`, `plan`, `implement`, `test` | `brainstorm` | Sub-skill to run |
+| `target` | path, URL, or description | required | What to operate on |
+
+## Guardrails
+
+1. Memory is append-only. Never delete history.
+2. Every action scored against rubric. No silent completion.
+3. Profile is user-controlled. Never change without asking.
+4. Evidence required. No fabricated metrics or claims.
+5. Learn from history. Compare current output to past executions.

--- a/skills/pos-build/evaluation/rubric.yml
+++ b/skills/pos-build/evaluation/rubric.yml
@@ -1,0 +1,49 @@
+domain: build
+version: 1
+
+actions:
+  plan:
+    passing_score: 8.0
+    dimensions:
+      - name: completeness
+        weight: 0.3
+        passing: 85
+      - name: sequencing
+        weight: 0.25
+        passing: 80
+      - name: risk_identification
+        weight: 0.25
+        passing: 85
+      - name: test_strategy
+        weight: 0.2
+        passing: 90
+  implement:
+    passing_score: 8.0
+    dimensions:
+      - name: correctness
+        weight: 0.35
+        passing: 90
+      - name: test_coverage
+        weight: 0.25
+        passing: 80
+      - name: minimal_change
+        weight: 0.2
+        passing: 85
+      - name: style_consistency
+        weight: 0.2
+        passing: 80
+  test:
+    passing_score: 8.0
+    dimensions:
+      - name: coverage
+        weight: 0.3
+        passing: 85
+      - name: behavioral_not_structural
+        weight: 0.3
+        passing: 85
+      - name: edge_cases
+        weight: 0.2
+        passing: 80
+      - name: readability
+        weight: 0.2
+        passing: 85

--- a/skills/pos-content/SKILL.md
+++ b/skills/pos-content/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: pos-content
+description: "Content composite — strategy, writing, audit, and refresh with brand voice memory. Replaces 10 fragmented content skills."
+argument-hint: "[strategy|write|audit|refresh] [topic or URL]"
+---
+
+# pos-content
+
+Content composite — strategy, writing, audit, and refresh with brand voice memory. Replaces 10 fragmented content skills.
+
+**Replaces:** content-gap-analysis, content-ops, content-quality-auditor, content-refresher, content-research-writer, content-strategy, unified-content, copywriting, copy-editing, social-content
+
+## Actions
+
+| Action | What |
+|--------|------|
+| `strategy` | Content strategy with audience analysis and calendar planning |
+| `write [topic]` | Create content (article, social post, email, landing page) |
+| `audit [url]` | Audit existing content for quality, freshness, and SEO alignment |
+| `refresh [url]` | Update stale content with current data and improved structure |
+
+## Routing
+
+1. Parse action from first argument
+2. Load domain memory from `~/.productionos/domains/pos-content/`
+3. If first run: auto-detect project context, create profile
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/pos-content/`:
+profile.yml (brand voice, audience, tone, platforms), content-calendar.jsonl (published + planned content), performance.jsonl (what content performed well), learnings.jsonl
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `strategy`, `write`, `audit`, `refresh` | `strategy` | Sub-skill to run |
+| `target` | path, URL, or description | required | What to operate on |
+
+## Guardrails
+
+1. Memory is append-only. Never delete history.
+2. Every action scored against rubric. No silent completion.
+3. Profile is user-controlled. Never change without asking.
+4. Evidence required. No fabricated metrics or claims.
+5. Learn from history. Compare current output to past executions.

--- a/skills/pos-content/evaluation/rubric.yml
+++ b/skills/pos-content/evaluation/rubric.yml
@@ -1,0 +1,55 @@
+domain: content
+version: 1
+
+actions:
+  strategy:
+    passing_score: 8.0
+    dimensions:
+      - name: audience_clarity
+        weight: 0.3
+        passing: 85
+      - name: channel_fit
+        weight: 0.3
+        passing: 80
+      - name: calendar_specificity
+        weight: 0.4
+        passing: 85
+  write:
+    passing_score: 8.0
+    dimensions:
+      - name: quality
+        weight: 0.3
+        passing: 85
+      - name: seo_alignment
+        weight: 0.25
+        passing: 80
+      - name: brand_voice
+        weight: 0.25
+        passing: 85
+      - name: readability
+        weight: 0.2
+        passing: 90
+  audit:
+    passing_score: 8.0
+    dimensions:
+      - name: coverage
+        weight: 0.3
+        passing: 80
+      - name: actionability
+        weight: 0.35
+        passing: 90
+      - name: freshness_check
+        weight: 0.35
+        passing: 85
+  refresh:
+    passing_score: 8.0
+    dimensions:
+      - name: improvement_delta
+        weight: 0.4
+        passing: 80
+      - name: accuracy
+        weight: 0.3
+        passing: 90
+      - name: seo_preserved
+        weight: 0.3
+        passing: 85

--- a/skills/pos-debug/SKILL.md
+++ b/skills/pos-debug/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: pos-debug
+description: "Debug composite — reproduce, hypothesize, test, fix with bug pattern memory. Replaces 4 debug skills."
+argument-hint: "[diagnose|fix|verify] [bug or error]"
+---
+
+# pos-debug
+
+Debug composite — reproduce, hypothesize, test, fix with bug pattern memory. Replaces 4 debug skills.
+
+**Replaces:** debug, unified-debug, systematic-debugging, investigate
+
+## Actions
+
+| Action | What |
+|--------|------|
+| `diagnose [bug]` | Reproduce + hypothesize + test — root cause analysis |
+| `fix [finding]` | Apply minimum fix for confirmed root cause |
+| `verify` | Re-run reproduction + regression test after fix |
+
+## Routing
+
+1. Parse action from first argument
+2. Load domain memory from `~/.productionos/domains/pos-debug/`
+3. If first run: auto-detect project context, create profile
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/pos-debug/`:
+bug-history.jsonl (past bugs with root causes), patterns.jsonl (recurring bug patterns in this codebase), learnings.jsonl
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `diagnose`, `fix`, `verify` | `diagnose` | Sub-skill to run |
+| `target` | path, URL, or description | required | What to operate on |
+
+## Guardrails
+
+1. Memory is append-only. Never delete history.
+2. Every action scored against rubric. No silent completion.
+3. Profile is user-controlled. Never change without asking.
+4. Evidence required. No fabricated metrics.
+5. Learn from history. Compare to past executions.

--- a/skills/pos-debug/evaluation/rubric.yml
+++ b/skills/pos-debug/evaluation/rubric.yml
@@ -1,0 +1,37 @@
+domain: debug
+version: 1
+
+actions:
+  diagnose:
+    passing_score: 8.0
+    dimensions:
+      - name: reproduction
+        weight: 0.3
+        passing: 95
+      - name: hypothesis_quality
+        weight: 0.35
+        passing: 85
+      - name: evidence_chain
+        weight: 0.35
+        passing: 90
+  fix:
+    passing_score: 8.0
+    dimensions:
+      - name: root_cause_addressed
+        weight: 0.4
+        passing: 95
+      - name: minimal_change
+        weight: 0.3
+        passing: 90
+      - name: regression_test
+        weight: 0.3
+        passing: 85
+  verify:
+    passing_score: 8.0
+    dimensions:
+      - name: repro_passes
+        weight: 0.5
+        passing: 100
+      - name: test_suite_passes
+        weight: 0.5
+        passing: 100

--- a/skills/pos-frontend/SKILL.md
+++ b/skills/pos-frontend/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: pos-frontend
+description: "Frontend composite — UI audit, design system upgrade, and UX analysis with design token memory. Replaces 10 frontend skills."
+argument-hint: "[audit|upgrade|design] [target]"
+---
+
+# pos-frontend
+
+Frontend composite — UI audit, design system upgrade, and UX analysis with design token memory. Replaces 10 frontend skills.
+
+**Replaces:** frontend-audit, frontend-design, frontend-upgrade, designer-upgrade, ux-genie, ux-replicator, interface-craft, design-consultation, design-review, plan-design-review
+
+## Actions
+
+| Action | What |
+|--------|------|
+| `audit [url]` | Full UI/UX audit — accessibility, responsive, interactions, performance |
+| `upgrade [target]` | Design system upgrade — tokens, components, patterns |
+| `design [feature]` | UX design — user stories, journey maps, mockups |
+
+## Routing
+
+1. Parse action from first argument
+2. Load domain memory from `~/.productionos/domains/pos-frontend/`
+3. If first run: auto-detect project context, create profile
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/pos-frontend/`:
+design-system.yml (tokens, colors, typography, spacing), component-inventory.jsonl (tracked components), audit-history.jsonl, learnings.jsonl
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `audit`, `upgrade`, `design` | `audit` | Sub-skill to run |
+| `target` | path, URL, or description | required | What to operate on |
+
+## Guardrails
+
+1. Memory is append-only. Never delete history.
+2. Every action scored against rubric. No silent completion.
+3. Profile is user-controlled. Never change without asking.
+4. Evidence required. No fabricated metrics.
+5. Learn from history. Compare to past executions.

--- a/skills/pos-frontend/evaluation/rubric.yml
+++ b/skills/pos-frontend/evaluation/rubric.yml
@@ -1,0 +1,43 @@
+domain: frontend
+version: 1
+
+actions:
+  audit:
+    passing_score: 8.0
+    dimensions:
+      - name: accessibility
+        weight: 0.3
+        passing: 85
+      - name: responsive
+        weight: 0.25
+        passing: 80
+      - name: interaction_coverage
+        weight: 0.25
+        passing: 80
+      - name: performance
+        weight: 0.2
+        passing: 85
+  upgrade:
+    passing_score: 8.0
+    dimensions:
+      - name: token_consistency
+        weight: 0.35
+        passing: 90
+      - name: component_coverage
+        weight: 0.35
+        passing: 85
+      - name: migration_safety
+        weight: 0.3
+        passing: 90
+  design:
+    passing_score: 8.0
+    dimensions:
+      - name: user_story_completeness
+        weight: 0.3
+        passing: 85
+      - name: journey_coverage
+        weight: 0.35
+        passing: 80
+      - name: mockup_fidelity
+        weight: 0.35
+        passing: 85

--- a/skills/pos-github/SKILL.md
+++ b/skills/pos-github/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: pos-github
+description: "GitHub composite — PR management, issue triage, release automation, and workflow management with project memory. Replaces 8 GitHub skills."
+argument-hint: "[pr|issue|release|workflow] [target]"
+---
+
+# pos-github
+
+GitHub composite — PR management, issue triage, release automation, and workflow management with project memory. Replaces 8 GitHub skills.
+
+**Replaces:** github-automation, github-code-review, github-multi-repo, github-project-management, github-release-management, github-workflow-automation, agent-github-pr-manager, agent-github-modes
+
+## Actions
+
+| Action | What |
+|--------|------|
+| `pr [action]` | PR lifecycle — create, review, merge, close |
+| `issue [action]` | Issue triage — create, label, assign, close |
+| `release [version]` | Release automation — changelog, tag, publish |
+| `workflow [action]` | CI/CD workflow management — create, debug, optimize |
+
+## Routing
+
+1. Parse action from first argument
+2. Load domain memory from `~/.productionos/domains/pos-github/`
+3. If first run: auto-detect project context, create profile
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/pos-github/`:
+repo-config.yml (default branch, labels, reviewers), pr-history.jsonl, release-log.jsonl, learnings.jsonl
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `pr`, `issue`, `release`, `workflow` | `pr` | Sub-skill to run |
+| `target` | path, URL, or description | required | What to operate on |
+
+## Guardrails
+
+1. Memory is append-only. Never delete history.
+2. Every action scored against rubric. No silent completion.
+3. Profile is user-controlled. Never change without asking.
+4. Evidence required. No fabricated metrics.
+5. Learn from history. Compare to past executions.

--- a/skills/pos-github/evaluation/rubric.yml
+++ b/skills/pos-github/evaluation/rubric.yml
@@ -1,0 +1,40 @@
+domain: github
+version: 1
+
+actions:
+  pr:
+    passing_score: 8.0
+    dimensions:
+      - name: review_quality
+        weight: 0.35
+        passing: 85
+      - name: merge_safety
+        weight: 0.35
+        passing: 90
+      - name: description_quality
+        weight: 0.3
+        passing: 80
+  issue:
+    passing_score: 8.0
+    dimensions:
+      - name: triage_accuracy
+        weight: 0.35
+        passing: 85
+      - name: label_correctness
+        weight: 0.35
+        passing: 90
+      - name: priority_assignment
+        weight: 0.3
+        passing: 80
+  release:
+    passing_score: 8.0
+    dimensions:
+      - name: changelog_completeness
+        weight: 0.35
+        passing: 90
+      - name: version_correctness
+        weight: 0.35
+        passing: 95
+      - name: tag_safety
+        weight: 0.3
+        passing: 90

--- a/skills/pos-n8n/SKILL.md
+++ b/skills/pos-n8n/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: pos-n8n
+description: "n8n composite — workflow creation, import, debugging, and monitoring with workflow memory. Replaces 33 n8n skills."
+argument-hint: "[create|import|debug|monitor] [workflow or node]"
+---
+
+# pos-n8n
+
+n8n composite — workflow creation, import, debugging, and monitoring with workflow memory. Replaces 33 n8n skills.
+
+**Replaces:** n8n-architect + 32 n8n-cli-* skills
+
+## Actions
+
+| Action | What |
+|--------|------|
+| `create [description]` | Generate n8n workflow from natural language description |
+| `import [source]` | Import workflow from template, JSON, or URL |
+| `debug [workflow]` | Debug failing workflow — trace execution, fix nodes |
+| `monitor` | Check workflow health, execution stats, error rates |
+
+## Routing
+
+1. Parse action from first argument
+2. Load domain memory from `~/.productionos/domains/pos-n8n/`
+3. If first run: auto-detect project context, create profile
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/pos-n8n/`:
+instance-config.yml (n8n URL, credentials, version), workflow-registry.jsonl (known workflows with status), node-patterns.jsonl (reusable node configurations), learnings.jsonl
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `create`, `import`, `debug`, `monitor` | `create` | Sub-skill to run |
+| `target` | path, URL, or description | required | What to operate on |
+
+## Guardrails
+
+1. Memory is append-only. Never delete history.
+2. Every action scored against rubric. No silent completion.
+3. Profile is user-controlled. Never change without asking.
+4. Evidence required. No fabricated metrics.
+5. Learn from history. Compare to past executions.

--- a/skills/pos-n8n/evaluation/rubric.yml
+++ b/skills/pos-n8n/evaluation/rubric.yml
@@ -1,0 +1,40 @@
+domain: n8n
+version: 1
+
+actions:
+  create:
+    passing_score: 8.0
+    dimensions:
+      - name: node_correctness
+        weight: 0.35
+        passing: 90
+      - name: flow_logic
+        weight: 0.3
+        passing: 85
+      - name: error_handling
+        weight: 0.35
+        passing: 80
+  debug:
+    passing_score: 8.0
+    dimensions:
+      - name: root_cause_found
+        weight: 0.4
+        passing: 90
+      - name: fix_correctness
+        weight: 0.35
+        passing: 90
+      - name: regression_check
+        weight: 0.25
+        passing: 85
+  monitor:
+    passing_score: 8.0
+    dimensions:
+      - name: metric_coverage
+        weight: 0.35
+        passing: 80
+      - name: alert_accuracy
+        weight: 0.35
+        passing: 85
+      - name: trend_analysis
+        weight: 0.3
+        passing: 80

--- a/skills/pos-plan/SKILL.md
+++ b/skills/pos-plan/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: pos-plan
+description: "Planning composite — CEO vision review, engineering architecture review, design review, and brainstorming with decision memory. Replaces 8 fragmented planning skills."
+argument-hint: "[ceo|eng|design|brainstorm] [target plan or feature]"
+---
+
+# pos-plan
+
+Planning composite — CEO vision review, engineering architecture review, design review, and brainstorming with decision memory. Replaces 8 fragmented planning skills.
+
+**Replaces:** plan-ceo-review, plan-eng-review, plan-design-review, plan-my-day, brainstorming, writing-plans, omni-plan, omni-plan-nth
+
+## Actions
+
+| Action | What |
+|--------|------|
+| `ceo [target]` | CEO/founder strategic review — 10-star framework, scope decisions |
+| `eng [target]` | Engineering architecture review — data flow, error paths, test matrix |
+| `design [target]` | Design review — UI/UX, design system, accessibility |
+| `brainstorm [idea]` | Idea exploration — understand, propose, design, approve |
+
+## Routing
+
+1. Parse action from first argument
+2. Load domain memory from `~/.productionos/domains/pos-plan/`
+3. If first run: auto-detect project context, create profile
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/pos-plan/`:
+profile.yml (project vision, constraints, team size), decision-log.jsonl (past scope decisions with rationale), architecture-snapshots.jsonl (system diagrams over time), learnings.jsonl
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `ceo`, `eng`, `design`, `brainstorm` | `ceo` | Sub-skill to run |
+| `target` | path, URL, or description | required | What to operate on |
+
+## Guardrails
+
+1. Memory is append-only. Never delete history.
+2. Every action scored against rubric. No silent completion.
+3. Profile is user-controlled. Never change without asking.
+4. Evidence required. No fabricated metrics or claims.
+5. Learn from history. Compare current output to past executions.

--- a/skills/pos-plan/evaluation/rubric.yml
+++ b/skills/pos-plan/evaluation/rubric.yml
@@ -1,0 +1,64 @@
+domain: plan
+version: 1
+
+actions:
+  ceo:
+    passing_score: 8.0
+    dimensions:
+      - name: problem_clarity
+        weight: 0.25
+        passing: 85
+      - name: ambition_level
+        weight: 0.25
+        passing: 80
+      - name: risk_coverage
+        weight: 0.25
+        passing: 85
+      - name: scope_specificity
+        weight: 0.25
+        passing: 90
+  eng:
+    passing_score: 8.0
+    dimensions:
+      - name: flow_tracing
+        weight: 0.3
+        passing: 85
+      - name: error_path_coverage
+        weight: 0.3
+        passing: 90
+      - name: test_matrix
+        weight: 0.2
+        passing: 80
+      - name: dependency_audit
+        weight: 0.2
+        passing: 85
+  design:
+    passing_score: 8.0
+    dimensions:
+      - name: consistency
+        weight: 0.3
+        passing: 85
+      - name: accessibility
+        weight: 0.3
+        passing: 80
+      - name: responsive
+        weight: 0.2
+        passing: 85
+      - name: interaction_coverage
+        weight: 0.2
+        passing: 80
+  brainstorm:
+    passing_score: 8.0
+    dimensions:
+      - name: understanding_depth
+        weight: 0.3
+        passing: 85
+      - name: approach_diversity
+        weight: 0.25
+        passing: 80
+      - name: trade_off_honesty
+        weight: 0.25
+        passing: 85
+      - name: design_specificity
+        weight: 0.2
+        passing: 90

--- a/skills/pos-qa/SKILL.md
+++ b/skills/pos-qa/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: pos-qa
+description: "QA composite — browser testing, health scoring, and evaluation with test result memory. Replaces 5 QA skills."
+argument-hint: "[test|audit|browse] [url or path]"
+---
+
+# pos-qa
+
+QA composite — browser testing, health scoring, and evaluation with test result memory. Replaces 5 QA skills.
+
+**Replaces:** qa, qa-only, browse, agentic-eval, self-eval
+
+## Actions
+
+| Action | What |
+|--------|------|
+| `test [url]` | Full QA — browser testing, health score 0-100, bug detection |
+| `audit [path]` | Code quality audit without browser (static analysis + tests) |
+| `browse [url]` | Headless browser interaction — navigate, screenshot, inspect |
+
+## Routing
+
+1. Parse action from first argument
+2. Load domain memory from `~/.productionos/domains/pos-qa/`
+3. If first run: auto-detect project context, create profile
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/pos-qa/`:
+test-history.jsonl (health scores over time), known-bugs.jsonl (tracked issues with status), baseline-screenshots/ (visual regression reference), learnings.jsonl
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `test`, `audit`, `browse` | `test` | Sub-skill to run |
+| `target` | path, URL, or description | required | What to operate on |
+
+## Guardrails
+
+1. Memory is append-only. Never delete history.
+2. Every action scored against rubric. No silent completion.
+3. Profile is user-controlled. Never change without asking.
+4. Evidence required. No fabricated metrics.
+5. Learn from history. Compare to past executions.

--- a/skills/pos-qa/evaluation/rubric.yml
+++ b/skills/pos-qa/evaluation/rubric.yml
@@ -1,0 +1,43 @@
+domain: qa
+version: 1
+
+actions:
+  test:
+    passing_score: 8.0
+    dimensions:
+      - name: page_coverage
+        weight: 0.25
+        passing: 85
+      - name: health_score_accuracy
+        weight: 0.3
+        passing: 85
+      - name: bug_specificity
+        weight: 0.25
+        passing: 90
+      - name: regression_check
+        weight: 0.2
+        passing: 80
+  audit:
+    passing_score: 8.0
+    dimensions:
+      - name: coverage
+        weight: 0.35
+        passing: 80
+      - name: finding_quality
+        weight: 0.35
+        passing: 90
+      - name: false_positive_rate
+        weight: 0.3
+        passing: 85
+  browse:
+    passing_score: 8.0
+    dimensions:
+      - name: evidence_quality
+        weight: 0.4
+        passing: 85
+      - name: accessibility_check
+        weight: 0.3
+        passing: 80
+      - name: responsive_check
+        weight: 0.3
+        passing: 80

--- a/skills/pos-research/SKILL.md
+++ b/skills/pos-research/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: pos-research
+description: "Research composite — quick lookup, deep investigation, and exhaustive multi-source research with citation memory. Replaces 5 research skills."
+argument-hint: "[quick|deep|exhaustive] [topic]"
+---
+
+# pos-research
+
+Research composite — quick lookup, deep investigation, and exhaustive multi-source research with citation memory. Replaces 5 research skills.
+
+**Replaces:** deep-research, max-research, research, research-and-plan, autoresearch
+
+## Actions
+
+| Action | What |
+|--------|------|
+| `quick [topic]` | Fast lookup — 10 sources, context7 docs, < 5 min |
+| `deep [topic]` | 8-phase pipeline — 500 sources, citation verification, 10-20 min |
+| `exhaustive [topic]` | Multi-agent swarm — 2000+ sources, cross-validation, 30-60 min |
+
+## Routing
+
+1. Parse action from first argument
+2. Load domain memory from `~/.productionos/domains/pos-research/`
+3. If first run: auto-detect project context, create profile
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/pos-research/`:
+research-log.jsonl (past research with topics and key findings), source-quality.jsonl (trusted vs unreliable sources), learnings.jsonl
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `quick`, `deep`, `exhaustive` | `quick` | Sub-skill to run |
+| `target` | path, URL, or description | required | What to operate on |
+
+## Guardrails
+
+1. Memory is append-only. Never delete history.
+2. Every action scored against rubric. No silent completion.
+3. Profile is user-controlled. Never change without asking.
+4. Evidence required. No fabricated metrics.
+5. Learn from history. Compare to past executions.

--- a/skills/pos-research/evaluation/rubric.yml
+++ b/skills/pos-research/evaluation/rubric.yml
@@ -1,0 +1,43 @@
+domain: research
+version: 1
+
+actions:
+  quick:
+    passing_score: 8.0
+    dimensions:
+      - name: answer_found
+        weight: 0.5
+        passing: 90
+      - name: source_quality
+        weight: 0.5
+        passing: 80
+  deep:
+    passing_score: 8.0
+    dimensions:
+      - name: source_diversity
+        weight: 0.25
+        passing: 80
+      - name: citation_verification
+        weight: 0.3
+        passing: 90
+      - name: synthesis_quality
+        weight: 0.25
+        passing: 85
+      - name: confidence_calibration
+        weight: 0.2
+        passing: 85
+  exhaustive:
+    passing_score: 8.0
+    dimensions:
+      - name: coverage
+        weight: 0.3
+        passing: 90
+      - name: cross_validation
+        weight: 0.3
+        passing: 85
+      - name: novel_insights
+        weight: 0.2
+        passing: 75
+      - name: confidence_calibration
+        weight: 0.2
+        passing: 90

--- a/skills/pos-review/SKILL.md
+++ b/skills/pos-review/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: pos-review
+description: "Code review composite — PR review, architecture review, and diff analysis with persistent review patterns. Replaces 7 fragmented review skills."
+argument-hint: "[pr|code|architecture] [PR number, file path, or branch]"
+---
+
+# pos-review
+
+Domain-aware code review pipeline with persistent review patterns. Reviews PRs for bugs and security issues, audits architecture for design flaws, and analyzes diffs for regression risk. Learns from past reviews — common issues in this codebase get flagged faster.
+
+**Replaces:** review, code-review, review-pr, review-delta, unified-review, github-code-review, requesting-code-review
+
+## Actions
+
+| Action | What | When to Use |
+|--------|------|------------|
+| `pr [number]` | Full PR review with 2-pass (critical + informational) | Before merging any PR |
+| `code [path]` | Review specific files or directories | During development |
+| `architecture [target]` | Architecture-level review for design patterns and coupling | Before major refactors |
+
+## Routing
+
+1. Parse action. Default to `pr` if a PR number is detected, `code` otherwise.
+2. Load review memory from `~/.productionos/domains/review/`
+3. If first run: detect codebase patterns, set review profile
+4. Dispatch to sub-skill with codebase context
+5. Score against rubric, update review history
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/review/`:
+
+| File | What | Updated |
+|------|------|---------|
+| `profile.yml` | Codebase patterns, common pitfalls, style conventions | First run + auto-updated |
+| `review-history.jsonl` | Past reviews with findings, false positives, accepted changes | After every review |
+| `patterns.jsonl` | Recurring issues in this codebase (N+1 queries, missing auth, etc.) | Extracted from review history |
+| `suppressions.jsonl` | Known acceptable patterns that shouldn't be flagged | Manual + auto-learned |
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `pr`, `code`, `architecture` | auto-detect | Review type |
+| `target` | PR number, file path, or branch | required | What to review |
+| `mode` | `strict`, `standard`, `quick` | `standard` | Review depth |
+
+## Sub-Skills
+
+### pr
+Two-pass PR review (adapted from code-reviewer agent):
+
+**Pass 1 — CRITICAL (must fix before merge):**
+- Security vulnerabilities (injection, XSS, auth bypass)
+- Data loss risks (migration without rollback, destructive operations)
+- Logic errors (wrong condition, missing null check, race condition)
+- Test coverage gaps (new code paths without tests)
+
+**Pass 2 — INFORMATIONAL (improve but don't block):**
+- Code style and naming conventions
+- Performance suggestions
+- Documentation gaps
+- Simplification opportunities
+
+Output: findings table with severity, file:line, evidence, and fix suggestion.
+
+### code
+Focused file/directory review:
+1. Read all files in scope
+2. Check against codebase patterns (from memory)
+3. Run checklist: error handling, input validation, test coverage, naming
+4. Compare to similar files in the codebase for consistency
+5. Report findings with specific line references
+
+### architecture
+System-level review:
+1. Map component dependencies (imports, API calls, data flow)
+2. Check coupling (are modules appropriately isolated?)
+3. Check for anti-patterns (god objects, circular deps, leaky abstractions)
+4. Assess scalability (N+1 queries, missing indexes, blocking operations)
+5. Produce architecture diagram + recommendations
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| PR not found | Check number, suggest recent PRs |
+| File not found | Search for similar paths |
+| No git history | Review files statically without diff context |
+| Codebase too large | Focus on changed files + their direct dependencies |
+| Finding is a known pattern | Check suppressions — if suppressed, skip silently |
+
+## Guardrails
+
+1. **Findings need evidence.** Every issue includes file:line and what specifically is wrong.
+2. **Critical before informational.** Never bury a security issue under style feedback.
+3. **Fix-first heuristic.** If you can auto-fix a mechanical issue (formatting, import order), do it.
+4. **Respect suppressions.** Learned acceptable patterns don't get re-flagged.
+5. **Never approve blindly.** If a review finds 0 issues, state confidence level.

--- a/skills/pos-review/evaluation/rubric.yml
+++ b/skills/pos-review/evaluation/rubric.yml
@@ -1,0 +1,59 @@
+domain: review
+version: 1
+
+actions:
+  pr:
+    passing_score: 8.0
+    dimensions:
+      - name: critical_coverage
+        description: "Security, data loss, logic errors checked. No CRITICAL missed."
+        weight: 0.35
+        passing: 95
+      - name: specificity
+        description: "Every finding has file:line, evidence, and fix suggestion"
+        weight: 0.25
+        passing: 90
+      - name: false_positive_rate
+        description: "Findings are real issues, not style nitpicks flagged as bugs"
+        weight: 0.20
+        passing: 85
+      - name: completeness
+        description: "All changed files reviewed. Dependencies of changed files checked."
+        weight: 0.20
+        passing: 90
+
+  code:
+    passing_score: 7.5
+    dimensions:
+      - name: pattern_awareness
+        description: "Codebase conventions detected and applied (naming, error handling, testing)"
+        weight: 0.30
+        passing: 80
+      - name: actionability
+        description: "Findings have specific fix instructions, not vague suggestions"
+        weight: 0.35
+        passing: 85
+      - name: consistency_check
+        description: "Compared to similar files in codebase for style/pattern consistency"
+        weight: 0.35
+        passing: 80
+
+  architecture:
+    passing_score: 8.0
+    dimensions:
+      - name: coupling_analysis
+        description: "Module dependencies mapped. Tight coupling flagged with evidence."
+        weight: 0.30
+        passing: 85
+      - name: scalability_check
+        description: "N+1, missing indexes, blocking ops, resource leaks identified"
+        weight: 0.30
+        passing: 80
+      - name: diagram_quality
+        description: "Architecture diagram is accurate, readable, and covers key components"
+        weight: 0.20
+        passing: 75
+      - name: recommendation_quality
+        description: "Suggestions are specific, prioritized, and feasible"
+        weight: 0.20
+        passing: 85

--- a/skills/pos-review/memory/schema.yml
+++ b/skills/pos-review/memory/schema.yml
@@ -1,0 +1,70 @@
+domain: review
+version: 1
+storage_path: "~/.productionos/domains/review/"
+
+profile:
+  file: profile.yml
+  fields:
+    - name: language
+      type: string
+      description: "Primary language (auto-detected)"
+    - name: framework
+      type: string
+      description: "Framework (auto-detected)"
+    - name: test_framework
+      type: string
+      description: "Test runner (auto-detected)"
+    - name: style_conventions
+      type: object
+      description: "Naming, formatting, import order patterns"
+    - name: common_pitfalls
+      type: list
+      description: "Recurring issues specific to this codebase"
+
+history:
+  file: review-history.jsonl
+  fields:
+    - name: timestamp
+      type: iso8601
+    - name: action
+      type: enum
+      values: [pr, code, architecture]
+    - name: target
+      type: string
+    - name: findings_count
+      type: integer
+    - name: critical_count
+      type: integer
+    - name: score
+      type: float
+    - name: duration_seconds
+      type: integer
+
+patterns:
+  file: patterns.jsonl
+  description: "Recurring issues in this codebase — loaded for faster detection"
+  fields:
+    - name: pattern
+      type: string
+      description: "What keeps appearing (e.g., 'missing null check on API responses in app/api/')"
+    - name: frequency
+      type: integer
+      description: "Times seen across reviews"
+    - name: severity
+      type: enum
+      values: [critical, high, medium, low]
+    - name: example_file
+      type: string
+
+suppressions:
+  file: suppressions.jsonl
+  description: "Known acceptable patterns — don't re-flag"
+  fields:
+    - name: pattern
+      type: string
+    - name: reason
+      type: string
+    - name: added_by
+      type: string
+    - name: timestamp
+      type: iso8601

--- a/skills/pos-security/SKILL.md
+++ b/skills/pos-security/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: pos-security
+description: "Security composite — OWASP audit, dependency scan, secret detection, and hardening with persistent vulnerability memory. Replaces 9 fragmented security skills."
+argument-hint: "[audit|scan|harden] [target path or URL]"
+---
+
+# pos-security
+
+Domain-aware security pipeline with shared vulnerability memory across sessions. Audits codebases against OWASP Top 10, scans dependencies for known CVEs, detects secrets in code, and applies hardening fixes. Learns from past audits — tracks which vulnerabilities recur and which fixes stick.
+
+**Replaces:** security-audit, security-requirement-extraction, security-scan, security-sast, security-hardening, security-dependencies, unified-security, attack-tree-construction, sast-configuration
+
+## Actions
+
+| Action | What | When to Use |
+|--------|------|------------|
+| `audit [path]` | Full OWASP/MITRE/NIST security audit | Before releases. After auth/payment changes. |
+| `scan` | Dependency vulnerability scan + secret detection | Before every PR. Weekly cadence. |
+| `harden [finding]` | Apply security fixes for specific findings | After audit identifies issues |
+
+## Routing
+
+1. Parse action. Default to `audit` if ambiguous.
+2. Load security memory from `~/.productionos/domains/security/`
+3. If first run: detect tech stack, set default scan profiles
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update vulnerability memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/security/`:
+
+| File | What | Updated |
+|------|------|---------|
+| `profile.yml` | Tech stack, auth framework, deployment target, compliance requirements | First run + manual |
+| `vuln-history.jsonl` | Past findings with status (open/fixed/accepted-risk) | After every audit |
+| `dependency-audit.jsonl` | Dependency scan results with CVE IDs and severity | After every scan |
+| `learnings.jsonl` | Patterns: recurring vulns, fixes that stuck, false positive suppressions | Extracted from audit deltas |
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `audit`, `scan`, `harden` | `audit` | Which sub-skill |
+| `target` | file path, directory, or URL | cwd | What to audit |
+| `compliance` | `owasp`, `soc2`, `hipaa`, `pci`, `all` | `owasp` | Which framework |
+
+## Sub-Skills
+
+### audit
+7-domain OWASP/MITRE/NIST sweep:
+1. **Authentication** — Session management, token handling, password policy, MFA
+2. **Authorization** — RBAC/ABAC, privilege escalation, IDOR
+3. **Input validation** — SQL injection, XSS, command injection, path traversal
+4. **Data protection** — Encryption at rest/transit, PII handling, secret storage
+5. **Configuration** — Default credentials, debug mode, CORS, security headers
+6. **Dependencies** — Known CVEs, outdated packages, license risks
+7. **Logging** — Audit trail, error handling (no stack traces leaked), monitoring
+
+Each domain scored independently. Overall score = weighted average.
+
+### scan
+Fast checks without full audit:
+- `npm audit` / `pip-audit` / `bundle audit` for known CVEs
+- Gitleaks for secrets in staged/committed files
+- Semgrep for SAST patterns (if installed)
+- License compatibility check
+
+### harden
+Apply specific fixes from audit findings:
+1. Read the finding from vuln-history.jsonl
+2. Read the affected file
+3. Apply minimum fix (don't refactor)
+4. Re-run the specific check to verify
+5. Mark finding as `fixed` in vuln-history.jsonl
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| No code to audit | Check path, suggest correct target |
+| npm/pip audit unavailable | Skip dependency scan, note in report |
+| Gitleaks not installed | Fall back to regex patterns |
+| Semgrep not installed | Skip SAST, note in report |
+| All findings are false positives | Log suppressions to learnings.jsonl with justification |
+| Finding already known | Check vuln-history — if accepted-risk, skip. If recurrence, flag |
+
+## Guardrails
+
+1. **Never suppress findings silently.** Every suppression requires justification logged to learnings.
+2. **Severity drives priority.** CRITICAL before HIGH before MEDIUM. No exceptions.
+3. **Verify fixes.** Re-run the check after hardening. Don't trust the change worked.
+4. **Compliance is additive.** SOC2 checks include OWASP. HIPAA includes SOC2 + health data.
+5. **Memory prevents regression.** Fixed vulns that recur are flagged as regression, not new finding.

--- a/skills/pos-security/evaluation/rubric.yml
+++ b/skills/pos-security/evaluation/rubric.yml
@@ -1,0 +1,55 @@
+domain: security
+version: 1
+
+actions:
+  audit:
+    passing_score: 8.0
+    dimensions:
+      - name: domain_coverage
+        description: "All 7 security domains examined (auth, authz, input, data, config, deps, logging)"
+        weight: 0.25
+        passing: 100
+      - name: finding_specificity
+        description: "Each finding has: file:line, severity, CWE/CVE reference, fix instruction"
+        weight: 0.30
+        passing: 90
+      - name: false_positive_rate
+        description: "Findings verified against code — not pattern-matching noise"
+        weight: 0.25
+        passing: 85
+      - name: compliance_mapping
+        description: "Findings mapped to compliance framework (OWASP ID, NIST control)"
+        weight: 0.20
+        passing: 80
+
+  scan:
+    passing_score: 7.0
+    dimensions:
+      - name: dependency_coverage
+        description: "All dependency managers scanned (npm, pip, bundler, etc.)"
+        weight: 0.35
+        passing: 90
+      - name: secret_detection
+        description: "Gitleaks or equivalent ran. Known secret patterns checked"
+        weight: 0.35
+        passing: 95
+      - name: recency
+        description: "CVE database is current (< 7 days old)"
+        weight: 0.30
+        passing: 80
+
+  harden:
+    passing_score: 9.0
+    dimensions:
+      - name: fix_correctness
+        description: "Fix addresses root cause, not symptom. Verified by re-running check"
+        weight: 0.40
+        passing: 95
+      - name: minimal_change
+        description: "Only security-relevant code changed. No refactoring"
+        weight: 0.30
+        passing: 90
+      - name: regression_check
+        description: "Existing tests still pass after fix"
+        weight: 0.30
+        passing: 100

--- a/skills/pos-security/memory/schema.yml
+++ b/skills/pos-security/memory/schema.yml
@@ -1,0 +1,81 @@
+domain: security
+version: 1
+storage_path: "~/.productionos/domains/security/"
+
+profile:
+  file: profile.yml
+  fields:
+    - name: tech_stack
+      type: string
+      description: "Languages, frameworks, runtimes (auto-detected)"
+    - name: auth_framework
+      type: string
+      description: "Auth system (Clerk, Auth0, JWT, Django auth, etc.)"
+    - name: deployment_target
+      type: string
+      description: "Where deployed (Vercel, AWS, Railway, etc.)"
+    - name: compliance
+      type: list
+      description: "Required compliance frameworks (owasp, soc2, hipaa, pci)"
+    - name: known_suppressions
+      type: list
+      description: "False positives to skip in future scans"
+
+history:
+  file: vuln-history.jsonl
+  fields:
+    - name: timestamp
+      type: iso8601
+    - name: finding_id
+      type: string
+    - name: severity
+      type: enum
+      values: [critical, high, medium, low, info]
+    - name: domain
+      type: enum
+      values: [auth, authz, input, data, config, deps, logging]
+    - name: file_path
+      type: string
+    - name: line
+      type: integer
+    - name: cwe
+      type: string
+    - name: status
+      type: enum
+      values: [open, fixed, accepted-risk, false-positive]
+    - name: fix_commit
+      type: string
+
+dependencies:
+  file: dependency-audit.jsonl
+  fields:
+    - name: timestamp
+      type: iso8601
+    - name: package
+      type: string
+    - name: version
+      type: string
+    - name: cve_id
+      type: string
+    - name: severity
+      type: enum
+      values: [critical, high, medium, low]
+    - name: fixed_in
+      type: string
+    - name: status
+      type: enum
+      values: [open, upgraded, accepted-risk]
+
+learnings:
+  file: learnings.jsonl
+  fields:
+    - name: timestamp
+      type: iso8601
+    - name: pattern
+      type: string
+    - name: confidence
+      type: float
+    - name: evidence
+      type: string
+    - name: applicable_actions
+      type: list

--- a/skills/pos-ship/SKILL.md
+++ b/skills/pos-ship/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: pos-ship
+description: "Ship composite — PR creation, deployment, canary monitoring, and rollback with release memory. Replaces 4 ship skills."
+argument-hint: "[pr|deploy|canary|rollback] [branch or target]"
+---
+
+# pos-ship
+
+Ship composite — PR creation, deployment, canary monitoring, and rollback with release memory. Replaces 4 ship skills.
+
+**Replaces:** ship, ship-safe, land-and-deploy, setup-deploy
+
+## Actions
+
+| Action | What |
+|--------|------|
+| `pr [branch]` | Self-eval -> review -> create PR with test plan |
+| `deploy [target]` | Push to production with pre-flight checks |
+| `canary` | Monitor deployment for errors, performance regression |
+| `rollback` | Revert last deployment with verification |
+
+## Routing
+
+1. Parse action from first argument
+2. Load domain memory from `~/.productionos/domains/pos-ship/`
+3. If first run: auto-detect project context, create profile
+4. Dispatch to `sub-skills/{action}.md`
+5. Score against `evaluation/rubric.yml`, update memory
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/pos-ship/`:
+release-log.jsonl (past releases with outcomes), deploy-config.yml (targets, environments), incident-log.jsonl (past deployment issues), learnings.jsonl
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `pr`, `deploy`, `canary`, `rollback` | `pr` | Sub-skill to run |
+| `target` | path, URL, or description | required | What to operate on |
+
+## Guardrails
+
+1. Memory is append-only. Never delete history.
+2. Every action scored against rubric. No silent completion.
+3. Profile is user-controlled. Never change without asking.
+4. Evidence required. No fabricated metrics.
+5. Learn from history. Compare to past executions.

--- a/skills/pos-ship/evaluation/rubric.yml
+++ b/skills/pos-ship/evaluation/rubric.yml
@@ -1,0 +1,40 @@
+domain: ship
+version: 1
+
+actions:
+  pr:
+    passing_score: 8.0
+    dimensions:
+      - name: self_eval_pass
+        weight: 0.3
+        passing: 80
+      - name: review_clear
+        weight: 0.35
+        passing: 85
+      - name: test_plan_present
+        weight: 0.35
+        passing: 90
+  deploy:
+    passing_score: 8.0
+    dimensions:
+      - name: preflight_pass
+        weight: 0.4
+        passing: 100
+      - name: monitoring_active
+        weight: 0.3
+        passing: 90
+      - name: rollback_plan
+        weight: 0.3
+        passing: 85
+  canary:
+    passing_score: 8.0
+    dimensions:
+      - name: metric_coverage
+        weight: 0.4
+        passing: 85
+      - name: regression_detection
+        weight: 0.35
+        passing: 90
+      - name: alert_accuracy
+        weight: 0.25
+        passing: 80

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: seo
+description: "SEO composite — technical audit, content creation, keyword research, and rank monitoring with persistent domain memory. Replaces 9 fragmented SEO skills."
+argument-hint: "[audit|create|research|monitor] [target URL or keyword]"
+---
+
+# seo
+
+Domain-aware SEO pipeline with shared memory across sessions. Audits sites for technical and content SEO issues, creates optimized content, researches keywords with competitive analysis, and monitors ranking changes. Learns from past executions — run #10 benefits from everything learned in runs #1-9.
+
+**Replaces:** seo-audit, seo-competitor-analysis, seo-content-writer, seo-ops, agentic-seo, ai-seo, on-page-seo-auditor, programmatic-seo, technical-seo-checker
+
+## Actions
+
+| Action | What | When to Use |
+|--------|------|------------|
+| `audit [url]` | Full technical + content + competitor SEO audit | Before optimization work. Monthly cadence. |
+| `create [type] [keyword]` | Generate SEO-optimized content (article, meta, schema, alt text) | When publishing new content |
+| `research [keyword]` | Keyword + competitor + SERP research with intent classification | Before content creation or strategy planning |
+| `monitor` | Check rank changes, detect regressions, compare to history | Weekly or after major changes |
+
+## Routing
+
+1. Parse action from first argument. Default to `audit` if ambiguous.
+2. Load domain memory from `~/.productionos/domains/seo/`
+3. If no profile exists: run first-time setup (ask niche, competitors, target keywords)
+4. Dispatch to `sub-skills/{action}.md`
+5. After completion: score against `evaluation/rubric.yml`, update memory, log to history
+
+## Domain Memory
+
+Stored at `~/.productionos/domains/seo/`:
+
+| File | What | Updated When |
+|------|------|-------------|
+| `profile.yml` | Niche, target audience, competitors, preferred tone, tech stack | First run + manual updates |
+| `keyword-bank.jsonl` | Researched keywords with volume, difficulty, intent, position | After every `research` action |
+| `audit-history.jsonl` | Past audit scores, issues found, issues fixed | After every `audit` action |
+| `content-log.jsonl` | Published content with target keywords and performance | After every `create` action |
+| `learnings.jsonl` | Patterns that improved rankings, content that performed | Extracted from audit deltas |
+
+### Memory Loading
+On invocation, load: profile + last 5 audit scores + top keywords + recent learnings. This gives the sub-skill domain context without overwhelming the context window.
+
+### First-Time Setup
+If no `profile.yml` exists, ask (one at a time):
+1. "What's your site URL and niche?" (e.g., "entropyandco.com, AI video production")
+2. "Who are your top 3 competitors?" (auto-suggest from SERP if possible)
+3. "What keywords matter most?" (seed list, expanded via research)
+
+## Evaluation
+
+Every action scored against `evaluation/rubric.yml`. See `evaluation/rubric.yml` for dimensions. Score logged to `audit-history.jsonl` or `content-log.jsonl`.
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `action` | `audit`, `create`, `research`, `monitor` | `audit` | Which sub-skill to run |
+| `target` | URL, keyword, or content type | required for audit/research | What to operate on |
+| `depth` | `quick`, `standard`, `deep` | `standard` | How thorough |
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| No profile exists | Run first-time setup before proceeding |
+| Target URL unreachable | Report error, suggest checking URL |
+| No keyword data available | Fall back to competitor analysis to discover keywords |
+| Audit finds 0 issues | Suspicious — re-run with deeper checks. Report "clean" with confidence level |
+| Memory directory missing | Create it. Initialize with empty files |
+
+## Guardrails
+
+1. **Never fabricate metrics.** All numbers come from tools or declared as estimates.
+2. **Cite sources.** Every recommendation links to the evidence (page URL, tool output, competitor example).
+3. **Memory is append-only.** Never delete past audit results. History enables trend analysis.
+4. **Profile is user-controlled.** Never change niche, competitors, or target keywords without asking.
+5. **Evaluation is mandatory.** Every action gets scored. No silent completion.

--- a/skills/seo/evaluation/rubric.yml
+++ b/skills/seo/evaluation/rubric.yml
@@ -1,0 +1,79 @@
+domain: seo
+version: 1
+
+actions:
+  audit:
+    passing_score: 8.0
+    dimensions:
+      - name: coverage
+        description: "Percentage of technical, content, and competitive areas examined"
+        weight: 0.25
+        passing: 80
+      - name: actionability
+        description: "Percentage of findings with specific fix instructions (file, page, exact change)"
+        weight: 0.30
+        passing: 90
+      - name: accuracy
+        description: "Percentage of real issues vs false positives (verified by evidence)"
+        weight: 0.25
+        passing: 85
+      - name: prioritization
+        description: "Fixes ordered by impact, not category. Top 3 are genuinely highest-impact"
+        weight: 0.20
+        passing: 80
+
+  create:
+    passing_score: 8.0
+    dimensions:
+      - name: keyword_optimization
+        description: "Primary keyword in title, H1, first paragraph, URL. Natural density (1-2%)"
+        weight: 0.25
+        passing: 85
+      - name: content_depth
+        description: "Word count competitive with SERP top 5. Covers subtopics comprehensively"
+        weight: 0.25
+        passing: 80
+      - name: eeat_signals
+        description: "Author expertise, citations, data references, freshness indicators"
+        weight: 0.25
+        passing: 75
+      - name: readability
+        description: "Clear structure (H2/H3), short paragraphs, scannable. Grade level appropriate"
+        weight: 0.25
+        passing: 85
+
+  research:
+    passing_score: 8.0
+    dimensions:
+      - name: keyword_diversity
+        description: "Mix of head, long-tail, and question keywords. Multiple intent types"
+        weight: 0.30
+        passing: 80
+      - name: data_freshness
+        description: "Volume and difficulty data from recent sources (< 30 days)"
+        weight: 0.25
+        passing: 75
+      - name: competitive_coverage
+        description: "At least 3 competitors analyzed. Gap analysis present"
+        weight: 0.25
+        passing: 80
+      - name: intent_classification
+        description: "Every keyword tagged: informational, navigational, transactional, commercial"
+        weight: 0.20
+        passing: 90
+
+  monitor:
+    passing_score: 7.0
+    dimensions:
+      - name: tracking_coverage
+        description: "Primary keywords tracked. New rankings detected"
+        weight: 0.40
+        passing: 80
+      - name: regression_detection
+        description: "Position drops flagged with possible cause analysis"
+        weight: 0.35
+        passing: 75
+      - name: trend_analysis
+        description: "Comparison to previous monitoring period. Direction clear"
+        weight: 0.25
+        passing: 70

--- a/skills/seo/memory/schema.yml
+++ b/skills/seo/memory/schema.yml
@@ -1,0 +1,111 @@
+domain: seo
+version: 1
+storage_path: "~/.productionos/domains/seo/"
+
+profile:
+  file: profile.yml
+  description: "Domain configuration — persists across all sessions"
+  fields:
+    - name: site_url
+      type: string
+      description: "Primary site URL"
+      required: true
+    - name: niche
+      type: string
+      description: "Industry or topic focus (e.g., 'AI video production')"
+      required: true
+    - name: competitors
+      type: list
+      description: "Top 3-5 competitor URLs"
+      required: true
+    - name: target_keywords
+      type: list
+      description: "Seed keywords (expanded via research)"
+    - name: tone
+      type: string
+      description: "Content voice (e.g., 'technical but accessible')"
+    - name: tech_stack
+      type: string
+      description: "CMS, hosting, analytics (e.g., 'Next.js, Vercel, PostHog')"
+    - name: content_frequency
+      type: string
+      description: "Publishing cadence (e.g., '2 articles/week')"
+
+history:
+  file: audit-history.jsonl
+  description: "Append-only log of audit executions with scores"
+  fields:
+    - name: timestamp
+      type: iso8601
+    - name: action
+      type: enum
+      values: [audit, create, research, monitor]
+    - name: target
+      type: string
+    - name: score
+      type: float
+    - name: duration_seconds
+      type: integer
+    - name: findings_count
+      type: integer
+    - name: top_issues
+      type: list
+
+keywords:
+  file: keyword-bank.jsonl
+  description: "Researched keywords with metrics — grows over time"
+  fields:
+    - name: keyword
+      type: string
+    - name: volume
+      type: integer
+    - name: difficulty
+      type: integer
+    - name: intent
+      type: enum
+      values: [informational, navigational, transactional, commercial]
+    - name: current_position
+      type: integer
+    - name: target_position
+      type: integer
+    - name: discovered_date
+      type: iso8601
+    - name: source
+      type: string
+
+content:
+  file: content-log.jsonl
+  description: "Published content tracking"
+  fields:
+    - name: timestamp
+      type: iso8601
+    - name: title
+      type: string
+    - name: url
+      type: string
+    - name: target_keyword
+      type: string
+    - name: word_count
+      type: integer
+    - name: content_type
+      type: enum
+      values: [article, landing, product, meta, schema]
+
+learnings:
+  file: learnings.jsonl
+  description: "Patterns extracted from audit-over-audit improvement deltas"
+  fields:
+    - name: timestamp
+      type: iso8601
+    - name: pattern
+      type: string
+      description: "What was learned (e.g., 'adding FAQ schema to product pages improved CTR')"
+    - name: confidence
+      type: float
+      description: "0.0-1.0 confidence in this pattern"
+    - name: evidence
+      type: string
+      description: "What data supports this (e.g., 'audit score +1.2 after FAQ schema on 5 pages')"
+    - name: applicable_actions
+      type: list
+      description: "Which actions benefit from this learning"

--- a/skills/seo/sub-skills/audit.md
+++ b/skills/seo/sub-skills/audit.md
@@ -1,0 +1,123 @@
+---
+name: seo-audit
+description: "Full technical + content + competitor SEO audit with scoring rubric"
+---
+
+# SEO Audit
+
+Comprehensive SEO audit that examines technical health, on-page optimization, content quality, and competitive positioning. Produces a scored report with prioritized fix recommendations.
+
+## Inputs
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `url` | site URL | required | Target site to audit |
+| `depth` | `quick`, `standard`, `deep` | `standard` | Audit thoroughness |
+
+### Depth Configuration
+
+| Depth | Pages | Checks | Time |
+|-------|-------|--------|------|
+| `quick` | Homepage + 5 key pages | Technical only | 2-5 min |
+| `standard` | Up to 50 pages | Technical + content + basic competitor | 10-20 min |
+| `deep` | Full crawl | Technical + content + competitor + backlink + schema | 30-60 min |
+
+## Phase 1: Technical Audit
+
+Check these for every page:
+
+| Check | Tool | Pass Criteria |
+|-------|------|--------------|
+| Page loads | curl/browser | HTTP 200, < 3s |
+| Mobile responsive | Lighthouse | Score > 90 |
+| Core Web Vitals | Lighthouse | LCP < 2.5s, CLS < 0.1, INP < 200ms |
+| HTTPS | curl | Valid SSL, no mixed content |
+| Canonical tags | HTML parse | Present and correct on every page |
+| Robots.txt | curl | Exists, not blocking important pages |
+| Sitemap.xml | curl | Exists, all URLs valid, recently updated |
+| Structured data | Schema.org validation | Valid JSON-LD on key pages |
+| Internal links | Crawl | No broken links, logical hierarchy |
+| Image optimization | HTML parse | Alt text present, images compressed |
+| Meta tags | HTML parse | Title (50-60 chars), description (150-160 chars) on every page |
+
+## Phase 2: Content Audit (standard + deep)
+
+For each key page:
+
+| Dimension | What to Check |
+|-----------|--------------|
+| Keyword targeting | Primary keyword in title, H1, first paragraph, URL slug |
+| Content depth | Word count competitive with SERP top 5 for target keyword |
+| E-E-A-T signals | Author byline, expertise indicators, citations, freshness date |
+| Internal linking | Links to/from related pages, anchor text relevant |
+| Content gaps | Topics covered by competitors but missing here |
+| Duplicate content | Check for near-duplicate pages cannibalizing each other |
+
+## Phase 3: Competitor Analysis (standard + deep)
+
+1. Identify top 3 SERP competitors for primary keywords (use profile.yml if available)
+2. Compare: content depth, page count, backlink profile, keyword coverage
+3. Find gaps: keywords competitors rank for that target site doesn't
+4. Find advantages: keywords target site owns that competitors don't
+
+## Phase 4: Score and Report
+
+### Scoring Rubric
+
+| Category | Weight | Score 1-10 | Criteria |
+|----------|--------|-----------|----------|
+| Technical health | 25% | | Page speed, mobile, SSL, structured data |
+| On-page SEO | 25% | | Meta tags, headings, keyword targeting |
+| Content quality | 25% | | Depth, E-E-A-T, freshness, uniqueness |
+| Competitive position | 25% | | Keyword coverage vs competitors |
+
+### Report Output
+
+Write to `.productionos/domains/seo/reports/audit-{date}.md`:
+
+```
+# SEO Audit Report — {url}
+Date: {date}
+Score: {X}/10
+
+## Technical ({X}/10)
+| Issue | Severity | Page | Fix |
+|-------|----------|------|-----|
+
+## On-Page ({X}/10)
+| Issue | Severity | Page | Fix |
+
+## Content ({X}/10)
+| Gap | Competitor Has | Priority |
+
+## Competitive ({X}/10)
+| Keyword | Our Position | Top Competitor | Gap |
+
+## Priority Fixes
+1. {highest impact fix with specific instructions}
+2. ...
+3. ...
+```
+
+## Phase 5: Update Memory
+
+1. Append to `audit-history.jsonl`: {date, url, score, issues_count, top_issues}
+2. Update `keyword-bank.jsonl` with any new keywords discovered
+3. Extract learnings: compare to last audit — what improved? what regressed?
+4. Append learnings to `learnings.jsonl`
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Site unreachable | Report error, check DNS/SSL/hosting |
+| Robots.txt blocks crawler | Report restriction, audit accessible pages only |
+| No competitors in profile | Auto-discover from SERP results |
+| All scores high | Flag as "healthy" with confidence. Suggest monitoring cadence |
+
+## Guardrails
+
+1. Never fabricate metrics. All scores backed by evidence.
+2. Prioritize fixes by impact, not by category order.
+3. Compare to previous audit (if in history) to show trend.
+4. Specific fixes: "Add alt text to hero image on /about" not "improve images."

--- a/templates/composite-skill/COMPOSITE-SPEC.md
+++ b/templates/composite-skill/COMPOSITE-SPEC.md
@@ -1,0 +1,174 @@
+# Composite Skill Specification
+
+A composite skill collapses multiple fragmented skills into a single domain-aware pipeline with shared memory, evaluation rubrics, and cross-session learning.
+
+## Directory Structure
+
+```
+skills/{domain}/
+  SKILL.md                    # Router — dispatches to sub-skills based on action
+  sub-skills/
+    audit.md                  # Full audit runbook for this domain
+    create.md                 # Creation/generation pipeline
+    research.md               # Domain-specific research protocol
+    monitor.md                # Tracking and regression detection (optional)
+  evaluation/
+    rubric.yml                # Scoring dimensions per action
+    checklist.yml             # Mandatory pre-completion checks
+  memory/
+    schema.yml                # What to persist across sessions
+```
+
+## Router SKILL.md Pattern
+
+```markdown
+---
+name: {domain}
+description: "{domain} composite — routes to audit, create, research, monitor sub-skills with shared domain memory"
+argument-hint: "[action] [target or args]"
+---
+
+# {domain}
+
+{One-paragraph description of what this composite does and why it exists.}
+
+## Actions
+
+| Action | What | Sub-skill |
+|--------|------|-----------|
+| `audit` | Full domain audit with scoring | sub-skills/audit.md |
+| `create` | Generate domain-specific output | sub-skills/create.md |
+| `research` | Deep domain research | sub-skills/research.md |
+| `monitor` | Track changes, detect regressions | sub-skills/monitor.md |
+
+## Routing
+
+1. Parse the action from the first argument
+2. Load domain memory from `~/.productionos/domains/{domain}/`
+3. Dispatch to the matching sub-skill
+4. After completion: update memory, run evaluation rubric, log result
+
+## Memory
+
+Domain memory is loaded before every action and updated after:
+- `profile.yml` — Domain configuration (niche, preferences, constraints)
+- `history.jsonl` — Past executions with scores and timestamps
+- `learnings.jsonl` — Patterns that worked or failed
+- `cache/` — Reusable research, analysis, templates
+
+## Evaluation
+
+Every action is scored against `evaluation/rubric.yml`. Score >= 8.0 passes.
+Score < 6.0 triggers escalation. Scores are logged to `history.jsonl`.
+```
+
+## Sub-Skill Pattern
+
+Each sub-skill follows the standard dense runbook format:
+- YAML frontmatter (name, description)
+- Inputs table
+- Numbered phases with protocols
+- Domain memory integration (read on start, write on complete)
+- Error handling table
+- Guardrails
+
+## Evaluation Rubric Pattern (rubric.yml)
+
+```yaml
+domain: {domain}
+version: 1
+
+actions:
+  audit:
+    passing_score: 8.0
+    dimensions:
+      - name: coverage
+        description: "Percentage of relevant areas examined"
+        weight: 0.3
+        passing: 80
+      - name: actionability
+        description: "Percentage of findings with specific fix instructions"
+        weight: 0.3
+        passing: 90
+      - name: accuracy
+        description: "Percentage of real issues vs false positives"
+        weight: 0.4
+        passing: 85
+
+  create:
+    passing_score: 8.0
+    dimensions:
+      - name: quality
+        description: "Output meets domain-specific quality standards"
+        weight: 0.4
+        passing: 85
+      - name: completeness
+        description: "All required elements present"
+        weight: 0.3
+        passing: 90
+      - name: originality
+        description: "Not duplicating existing content"
+        weight: 0.3
+        passing: 80
+```
+
+## Memory Schema Pattern (schema.yml)
+
+```yaml
+domain: {domain}
+version: 1
+
+profile:
+  fields:
+    - name: niche
+      type: string
+      description: "Industry or topic focus"
+    - name: tech_stack
+      type: list
+      description: "Relevant technologies"
+    - name: preferences
+      type: object
+      description: "Domain-specific user preferences"
+
+history:
+  format: jsonl
+  fields: [timestamp, action, target, score, duration, findings_count]
+
+learnings:
+  format: jsonl
+  fields: [timestamp, pattern, confidence, context, applicable_actions]
+```
+
+## How Memory Works
+
+### On Composite Invocation
+1. Check `~/.productionos/domains/{domain}/profile.yml` exists
+2. If not: run first-time setup (ask 2-3 domain questions, save profile)
+3. Load profile + last 10 history entries + all learnings with confidence > 0.7
+4. Pass as context to the sub-skill
+
+### On Completion
+1. Score the output against rubric.yml
+2. Append to history.jsonl: {timestamp, action, target, score, duration}
+3. Extract learnings: what worked? what didn't? what to try next?
+4. Append learnings with confidence score to learnings.jsonl
+5. Optionally write to Obsidian: ~/SecondBrain/wiki/domains/{domain}/
+
+## Composites Defined
+
+| Composite | Absorbs | Actions |
+|-----------|---------|---------|
+| `/seo` | 9 SEO skills | audit, create, research, monitor |
+| `/ads` | 20 ads skills | audit, create, optimize, report |
+| `/content` | 10 content skills | strategy, write, audit, refresh |
+| `/security` | 9 security skills | audit, scan, harden |
+| `/frontend` | 10 frontend skills | audit, upgrade, design |
+| `/review` | 7 review skills | pr, code, architecture |
+| `/plan` | 8 planning skills | ceo, eng, design, brainstorm |
+| `/build` | 6 build skills | brainstorm, plan, implement, test |
+| `/debug` | 4 debug skills | diagnose, fix, verify |
+| `/research` | 5 research skills | quick, deep, exhaustive |
+| `/ship` | 4 shipping skills | pr, deploy, canary |
+| `/qa` | 5 QA skills | test, audit, browse |
+| `/github` | 8 GitHub skills | pr, issue, release, workflow |
+| `/n8n` | 33 n8n skills | create, import, debug, monitor |


### PR DESCRIPTION
## Summary
New composite skill architecture that collapses fragmented skills into domain-aware pipelines with shared memory, evaluation rubrics, and cross-session learning.

### What's new
- `templates/composite-skill/COMPOSITE-SPEC.md` — Pattern template for all composites
- `skills/seo/` — First reference composite with:
  - Router SKILL.md (4 actions: audit, create, research, monitor)
  - `sub-skills/audit.md` — Full 4-phase audit runbook
  - `evaluation/rubric.yml` — Per-action scoring dimensions with weights
  - `memory/schema.yml` — Domain persistence (profile, keywords, audit history, learnings)

### Architecture
```
skills/{domain}/
  SKILL.md              # Router
  sub-skills/           # Action runbooks
  evaluation/           # Rubrics + checklists
  memory/               # Persistence schemas
```

### Impact
- 9 fragmented SEO skills -> 1 composite with shared memory
- Pattern applies to all 14 planned composites (138 skills -> 14 commands)

## Test plan
- [ ] `bun test` passes
- [ ] COMPOSITE-SPEC.md is self-contained and implementable
- [ ] SEO composite has all required sections (router, sub-skills, evaluation, memory)